### PR TITLE
Fix KPackageStructure deprecation

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,4 +1,5 @@
 {
+    "KPackageStructure": "KWin/Effect",
     "KPlugin": {
         "Authors": [
             {
@@ -10,10 +11,7 @@
         "EnabledByDefault": false,
         "Id": "kwin_forceblur",
         "License": "GPL",
-        "Name": "Force Blur",
-        "ServiceTypes": [
-            "KWin/Effect"
-        ]
+        "Name": "Force Blur"
     },
     "X-KDE-ConfigModule": "kwin_forceblur_config",
     "org.kde.kwin.effect": {


### PR DESCRIPTION
This is from the Plasmoid docs so I'm not sure if this applies here too but I'm fairly certain this is the new way here too

https://develop.kde.org/docs/plasma/widget/porting_kf6/#porting-an-existing-plasmoid

> the KPlugin section may still contain the ServiceTypes key. This needs to be replaced by a KPackageStructure entry in the json's top level.