### PR TITLE
develop: add option to mark windows as translucent

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -215,6 +215,7 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
     m_roundCornersOfMaximizedWindows = BlurConfig::roundCornersOfMaximizedWindows();
     m_blurMenus = BlurConfig::blurMenus();
     m_blurDocks = BlurConfig::blurDocks();
+    m_paintAsTranslucent = BlurConfig::paintAsTranslucent();
 
     updateCornerRegions();
 
@@ -482,6 +483,11 @@ void BlurEffect::prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseco
 void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime)
 {
     // this effect relies on prePaintWindow being called in the bottom to top order
+
+    // fix artifacts for some translucent windows
+    if (m_paintAsTranslucent && shouldForceBlur(w)) {
+        data.setTranslucent();
+    }
 
     effects->prePaintWindow(w, data, presentTime);
 

--- a/src/blur.h
+++ b/src/blur.h
@@ -136,6 +136,7 @@ private:
     bool m_roundCornersOfMaximizedWindows;
     bool m_blurMenus;
     bool m_blurDocks;
+    bool m_paintAsTranslucent;
 
     // Regions to subtract from the blurred region
     QRegion m_topLeftCorner;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -43,5 +43,8 @@ class3</default>
         <entry name="BlurDocks" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="PaintAsTranslucent" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -225,6 +225,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="kcfg_PaintAsTranslucent">
+        <property name="text">
+         <string>Paint windows as non-opaque (fixes artifacts for some transparent windows)</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This PR adds a fix for artifacts caused by some windows not being fully repainted when using a translucent color scheme.

https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/c3712289-4d59-4578-8f1d-ad25a0a9c66f

