### PR TITLE
add fake blur

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -21,6 +21,7 @@
 #include "wayland/surface.h"
 
 #include <QGuiApplication>
+#include <QImage>
 #include <QMatrix4x4>
 #include <QScreen>
 #include <QTime>
@@ -89,6 +90,18 @@ BlurEffect::BlurEffect()
         m_noisePass.mvpMatrixLocation = m_noisePass.shader->uniformLocation("modelViewProjectionMatrix");
         m_noisePass.noiseTextureSizeLocation = m_noisePass.shader->uniformLocation("noiseTextureSize");
         m_noisePass.texStartPosLocation = m_noisePass.shader->uniformLocation("texStartPos");
+    }
+
+    m_texturePass.shader = ShaderManager::instance()->generateShaderFromFile(ShaderTrait::MapTexture,
+                                                                            QStringLiteral(":/effects/blur/shaders/vertex.vert"),
+                                                                            QStringLiteral(":/effects/blur/shaders/texture.frag"));
+    if (!m_texturePass.shader) {
+        qCWarning(KWIN_BLUR) << "Failed to load noise pass shader";
+        return;
+    } else {
+        m_texturePass.mvpMatrixLocation = m_texturePass.shader->uniformLocation("modelViewProjectionMatrix");
+        m_texturePass.textureSizeLocation = m_texturePass.shader->uniformLocation("textureSize");
+        m_texturePass.texStartPosLocation = m_texturePass.shader->uniformLocation("texStartPos");
     }
 
     initBlurStrengthValues();
@@ -216,6 +229,14 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
     m_blurMenus = BlurConfig::blurMenus();
     m_blurDocks = BlurConfig::blurDocks();
     m_paintAsTranslucent = BlurConfig::paintAsTranslucent();
+    m_fakeBlur = BlurConfig::fakeBlur();
+    m_fakeBlurImage = BlurConfig::fakeBlurImage();
+
+    QImage fakeBlurImage(m_fakeBlurImage);
+    m_hasValidFakeBlurTexture = !fakeBlurImage.isNull();
+    if (m_hasValidFakeBlurTexture) {
+        m_texturePass.texture = GLTexture::upload(fakeBlurImage);
+    }
 
     updateCornerRegions();
 
@@ -804,35 +825,58 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
     vbo->bindArrays();
 
-    // The downsample pass of the dual Kawase algorithm: the background will be scaled down 50% every iteration.
-    {
-        ShaderManager::instance()->pushShader(m_downsamplePass.shader.get());
+    if (m_fakeBlur && m_hasValidFakeBlurTexture) {
+        ShaderManager::instance()->pushShader(m_texturePass.shader.get());
 
-        QMatrix4x4 projectionMatrix;
-        projectionMatrix.ortho(QRectF(0.0, 0.0, backgroundRect.width(), backgroundRect.height()));
+        QMatrix4x4 projectionMatrix = data.projectionMatrix();
+        projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
 
-        m_downsamplePass.shader->setUniform(m_downsamplePass.mvpMatrixLocation, projectionMatrix);
-        m_downsamplePass.shader->setUniform(m_downsamplePass.offsetLocation, float(m_offset));
+        m_texturePass.shader->setUniform(m_texturePass.mvpMatrixLocation, projectionMatrix);
+        m_texturePass.shader->setUniform(m_texturePass.textureSizeLocation, QVector2D(m_texturePass.texture.get()->width(), m_texturePass.texture.get()->height()));
+        m_texturePass.shader->setUniform(m_texturePass.texStartPosLocation, QVector2D(0, 0));
 
-        for (size_t i = 1; i < renderInfo.framebuffers.size(); ++i) {
-            const auto &read = renderInfo.framebuffers[i - 1];
-            const auto &draw = renderInfo.framebuffers[i];
+        m_texturePass.texture.get()->bind();
 
-            const QVector2D halfpixel(0.5 / read->colorAttachment()->width(),
-                                      0.5 / read->colorAttachment()->height());
-            m_downsamplePass.shader->setUniform(m_downsamplePass.halfpixelLocation, halfpixel);
+        glEnable(GL_BLEND);
+        float o = 1.0f - (opacity);
+        o = 1.0f - o * o;
+        glBlendColor(0, 0, 0, o);
+        glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
 
-            read->colorAttachment()->bind();
+        vbo->draw(GL_TRIANGLES, 6, vertexCount);
 
-            GLFramebuffer::pushFramebuffer(draw.get());
-            vbo->draw(GL_TRIANGLES, 0, 6);
-        }
+        glDisable(GL_BLEND);
 
         ShaderManager::instance()->popShader();
-    }
+    } else {
+        // The downsample pass of the dual Kawase algorithm: the background will be scaled down 50% every iteration.
+        {
+            ShaderManager::instance()->pushShader(m_downsamplePass.shader.get());
 
-    // The upsample pass of the dual Kawase algorithm: the background will be scaled up 200% every iteration.
-    {
+            QMatrix4x4 projectionMatrix;
+            projectionMatrix.ortho(QRectF(0.0, 0.0, backgroundRect.width(), backgroundRect.height()));
+
+            m_downsamplePass.shader->setUniform(m_downsamplePass.mvpMatrixLocation, projectionMatrix);
+            m_downsamplePass.shader->setUniform(m_downsamplePass.offsetLocation, float(m_offset));
+
+            for (size_t i = 1; i < renderInfo.framebuffers.size(); ++i) {
+                const auto &read = renderInfo.framebuffers[i - 1];
+                const auto &draw = renderInfo.framebuffers[i];
+
+                const QVector2D halfpixel(0.5 / read->colorAttachment()->width(),
+                                        0.5 / read->colorAttachment()->height());
+                m_downsamplePass.shader->setUniform(m_downsamplePass.halfpixelLocation, halfpixel);
+
+                read->colorAttachment()->bind();
+
+                GLFramebuffer::pushFramebuffer(draw.get());
+                vbo->draw(GL_TRIANGLES, 0, 6);
+            }
+
+            ShaderManager::instance()->popShader();
+        }
+
+        // The upsample pass of the dual Kawase algorithm: the background will be scaled up 200% every iteration.
         ShaderManager::instance()->pushShader(m_upsamplePass.shader.get());
 
         QMatrix4x4 projectionMatrix;
@@ -884,37 +928,37 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         }
 
         ShaderManager::instance()->popShader();
-    }
 
-    if (m_noiseStrength > 0) {
-        // Apply an additive noise onto the blurred image. The noise is useful to mask banding
-        // artifacts, which often happens due to the smooth color transitions in the blurred image.
+        if (m_noiseStrength > 0) {
+            // Apply an additive noise onto the blurred image. The noise is useful to mask banding
+            // artifacts, which often happens due to the smooth color transitions in the blurred image.
 
-        glEnable(GL_BLEND);
-        if (opacity < 1.0) {
-            glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE);
-        } else {
-            glBlendFunc(GL_ONE, GL_ONE);
+            glEnable(GL_BLEND);
+            if (opacity < 1.0) {
+                glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE);
+            } else {
+                glBlendFunc(GL_ONE, GL_ONE);
+            }
+
+            if (GLTexture *noiseTexture = ensureNoiseTexture()) {
+                ShaderManager::instance()->pushShader(m_noisePass.shader.get());
+
+                QMatrix4x4 projectionMatrix = data.projectionMatrix();
+                projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
+
+                m_noisePass.shader->setUniform(m_noisePass.mvpMatrixLocation, projectionMatrix);
+                m_noisePass.shader->setUniform(m_noisePass.noiseTextureSizeLocation, QVector2D(noiseTexture->width(), noiseTexture->height()));
+                m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, QVector2D(deviceBackgroundRect.topLeft()));
+
+                noiseTexture->bind();
+
+                vbo->draw(GL_TRIANGLES, 6, vertexCount);
+
+                ShaderManager::instance()->popShader();
+            }
+
+            glDisable(GL_BLEND);
         }
-
-        if (GLTexture *noiseTexture = ensureNoiseTexture()) {
-            ShaderManager::instance()->pushShader(m_noisePass.shader.get());
-
-            QMatrix4x4 projectionMatrix = data.projectionMatrix();
-            projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
-
-            m_noisePass.shader->setUniform(m_noisePass.mvpMatrixLocation, projectionMatrix);
-            m_noisePass.shader->setUniform(m_noisePass.noiseTextureSizeLocation, QVector2D(noiseTexture->width(), noiseTexture->height()));
-            m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, QVector2D(deviceBackgroundRect.topLeft()));
-
-            noiseTexture->bind();
-
-            vbo->draw(GL_TRIANGLES, 6, vertexCount);
-
-            ShaderManager::instance()->popShader();
-        }
-
-        glDisable(GL_BLEND);
     }
 
     vbo->unbindArrays();

--- a/src/blur.h
+++ b/src/blur.h
@@ -12,6 +12,7 @@
 #include "window.h"
 
 #include <QList>
+#include <QImage>
 
 #include <unordered_map>
 
@@ -116,6 +117,16 @@ private:
         int noiseTextureStength = 0;
     } m_noisePass;
 
+    struct
+    {
+        std::unique_ptr<GLShader> shader;
+        int mvpMatrixLocation;
+        int textureSizeLocation;
+        int texStartPosLocation;
+
+        std::unique_ptr<GLTexture> texture;
+    } m_texturePass;
+
     bool m_valid = false;
     long net_wm_blur_region = 0;
     QRegion m_paintedArea; // keeps track of all painted areas (from bottom to top)
@@ -137,6 +148,10 @@ private:
     bool m_blurMenus;
     bool m_blurDocks;
     bool m_paintAsTranslucent;
+    bool m_fakeBlur;
+    QString m_fakeBlurImage;
+
+    bool m_hasValidFakeBlurTexture;
 
     // Regions to subtract from the blurred region
     QRegion m_topLeftCorner;

--- a/src/blur.h
+++ b/src/blur.h
@@ -12,7 +12,6 @@
 #include "window.h"
 
 #include <QList>
-#include <QImage>
 
 #include <unordered_map>
 
@@ -78,7 +77,7 @@ public Q_SLOTS:
 
 private:
     void initBlurStrengthValues();
-    QRegion blurRegion(EffectWindow *w) const;
+    QRegion blurRegion(EffectWindow *w, bool noRoundedCorners = false) const;
     QRegion decorationBlurRegion(const EffectWindow *w) const;
     bool decorationSupportsBlurBehind(const EffectWindow *w) const;
     bool shouldBlur(const EffectWindow *w, int mask, const WindowPaintData &data) const;
@@ -87,6 +86,7 @@ private:
     void updateCornerRegions();
     void blur(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data);
     GLTexture *ensureNoiseTexture();
+    bool hasFakeBlur(EffectWindow *w) const;
 
 private:
     struct

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -46,5 +46,11 @@ class3</default>
         <entry name="PaintAsTranslucent" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="FakeBlur" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="FakeBlurImage" type="String">
+            <default></default>
+        </entry>
     </group>
 </kcfg>

--- a/src/blur.qrc
+++ b/src/blur.qrc
@@ -4,6 +4,8 @@
   <file>shaders/downsample_core.frag</file>
   <file>shaders/noise.frag</file>
   <file>shaders/noise_core.frag</file>
+  <file>shaders/texture.frag</file>
+  <file>shaders/texture_core.frag</file>
   <file>shaders/upsample.frag</file>
   <file>shaders/upsample_core.frag</file>
   <file>shaders/vertex.vert</file>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -172,6 +172,37 @@
    <item>
     <widget class="QGroupBox">
      <property name="title">
+      <string>Fake blur</string>
+     </property>
+     <layout class="QVBoxLayout">
+      <item>
+       <widget class="QCheckBox" name="kcfg_FakeBlur">
+        <property name="text">
+         <string>Fake blur</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout">
+        <item>
+         <widget class="QLabel">
+          <property name="text">
+           <string>Path to image</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="kcfg_FakeBlurImage">
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox">
+     <property name="title">
       <string>Force blur</string>
      </property>
      <layout class="QVBoxLayout">

--- a/src/shaders/texture.frag
+++ b/src/shaders/texture.frag
@@ -1,0 +1,12 @@
+uniform sampler2D texUnit;
+uniform vec2 textureSize;
+uniform vec2 texStartPos;
+
+varying vec2 uv;
+
+void main(void)
+{
+    vec2 tex = vec2((texStartPos.xy + gl_FragCoord.xy) / textureSize);
+
+    gl_FragColor = vec4(texture2D(texUnit, tex).rgb, 0);
+}

--- a/src/shaders/texture_core.frag
+++ b/src/shaders/texture_core.frag
@@ -1,0 +1,16 @@
+#version 140
+
+uniform sampler2D texUnit;
+uniform vec2 textureSize;
+uniform vec2 texStartPos;
+
+in vec2 uv;
+
+out vec4 fragColor;
+
+void main(void)
+{
+    vec2 tex = vec2((texStartPos.xy + gl_FragCoord.xy) / textureSize);
+
+    fragColor = vec4(texture(texUnit, tex).rgb, 0);
+}


### PR DESCRIPTION
Fake blur works by drawing an already blurred image behind the window, which results in lower GPU load as KWin doesn't have to blur anything and it also doesn't have to paint everything behind the window.

Currently, the image must be blurred manually in an image editor. In the future, that will be done automatically when the effect is loaded.

https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/492ea9b9-f3eb-457b-ab4a-28f2bfd43cea

Also works with multiple screens, as long as the wallpapers and resolutions are the same.
![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/641b840b-2559-40a3-b469-9f0c8a54ab71)

Closes #41.

# To do
- [x] Windows with fake blur should always be considered as fully opaque, so that KWin doesn't paint everything behind them
