### PR TITLE
blur/rounded-corners: rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kwin-effects-forceblur [![AUR Version](https://img.shields.io/aur/version/kwin-effects-forceblur)](https://aur.archlinux.org/packages/kwin-effects-forceblur)
-A fork of the KWin Blur effect for KDE Plasma 6 with the ability to blur any window on Wayland and X11.
+Kwin-effects-forceblur (name subject to change) is a fork of the KWin Blur effect for KDE Plasma 6 with several improvements and bug fixes.
 
 Latest features are available on the ``develop`` branch.
 
@@ -8,9 +8,15 @@ Latest features are available on the ``develop`` branch.
 
 # Features
 - Wayland support
+- Force blur
+- Rounded corners with optional anti-aliasing
 - Draw image behind windows instead of blurring (can be used with a blurred image of the wallpaper in order to achieve a very similar effect to blur but with **much** lower GPU usage)
-- Rounded corners
-- Fix for [artifacts](https://github.com/taj-ny/kwin-effects-forceblur/pull/38) when using a transparent color scheme
+
+### Bug fixes
+Fixes for blur-related Plasma bugs that haven't been patched yet.
+
+- Blur may sometimes disappear during animations
+- [Transparent color schemes don't work properly with the Breeze application style](https://github.com/taj-ny/kwin-effects-forceblur/pull/38)
 
 # Installation
 <details>

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Kwin-effects-forceblur (name subject to change) is a fork of the KWin Blur effec
 
 Latest features are available on the ``develop`` branch.
 
-![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/9d2f337e-badd-4d95-ba55-96c80202e196)
-<sup>Window opacity has been set to 85% for System Settings and Dolphin, Firefox uses a transparent theme | [NixOS configuration](https://github.com/taj-ny/nix-config)</sup>
+![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/1078cf12-e6da-43c7-80b4-d90a8b0f3404)
+<sup>Window opacity has been set to 85% for System Settings, Dolphin and VSCodium, Firefox uses a transparent theme | [NixOS configuration](https://github.com/taj-ny/nix-config)</sup>
 
 # Features
 - Wayland support

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713537308,
-        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
+        "lastModified": 1715087517,
+        "narHash": "sha256-CLU5Tsg24Ke4+7sH8azHWXKd0CFd4mhLWfhYgUiDBpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
+        "rev": "b211b392b8486ee79df6cdfb1157ad2133427a29",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715087517,
-        "narHash": "sha256-CLU5Tsg24Ke4+7sH8azHWXKd0CFd4mhLWfhYgUiDBpQ=",
+        "lastModified": 1718160348,
+        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b211b392b8486ee79df6cdfb1157ad2133427a29",
+        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
         "type": "github"
       },
       "original": {

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -511,6 +511,16 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
     bool hasFakeBlur = m_fakeBlur && m_hasValidFakeBlurTexture && !blurArea.isEmpty();
     if (hasFakeBlur) {
         data.opaque += blurArea;
+
+        const auto windowGeometry = w->frameGeometry();
+        if (m_topCornerRadius) {
+            data.opaque -= QRect(windowGeometry.x(), windowGeometry.y(), m_topCornerRadius, m_topCornerRadius);
+            data.opaque -= QRect(windowGeometry.x() + windowGeometry.width() - m_topCornerRadius, windowGeometry.y(), m_topCornerRadius, m_topCornerRadius);
+        }
+        if (m_bottomCornerRadius) {
+            data.opaque -= QRect(windowGeometry.x(), windowGeometry.y() + windowGeometry.height() - m_bottomCornerRadius, m_bottomCornerRadius, m_bottomCornerRadius);
+            data.opaque -= QRect(windowGeometry.x() + windowGeometry.width() - m_bottomCornerRadius, windowGeometry.y() + windowGeometry.height() - m_bottomCornerRadius, m_bottomCornerRadius, m_bottomCornerRadius);
+        }
     }
 
     if (shouldForceBlur(w) && m_paintAsTranslucent) {

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -806,7 +806,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     bool roundTopRightCorner = false;
     bool roundBottomLeftCorner = false;
     bool roundBottomRightCorner = false;
-    if (hasRoundedCorners) {
+    const bool isMaximized = effects->clientArea(MaximizeArea, effects->activeScreen(), effects->currentDesktop()) == w->frameGeometry();
+    if (hasRoundedCorners && ((!w->isFullScreen() && !isMaximized) || m_roundCornersOfMaximizedWindows)) {
         if (w->isDock()) {
             // Only round floating panels. If the pixel at (0, height / 2) for horizontal panels and (width / 2, 0)
             // for vertical panels doesn't belong to the blur region, the panel is most likely floating. The (0,0)

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1016,6 +1016,20 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
     vbo->bindArrays();
 
+    /*
+     * The anti-aliasing implementation is actually really bad, but that's the best I can do for now. Suprisingly,
+     * there are no performance issues.
+     *
+     * Anti-aliasing is done by a shader that paints rounded rectangles. It's a modified version of
+     * https://www.shadertoy.com/view/ldfSDj.
+     * The shader requires two textures: the blur region before being blurred and after being blurred.
+     * The first texture can simply be taken from renderInfo.textures[0], as it's left unchanged.
+     * The second texture is more tricky. We could just blit, but that's slow. A faster solution is to create a virtual
+     * framebuffer with a texture attached to it and paint the blur in that framebuffer instead of the screen.
+     *
+     * Since only a fragment of the window may be painted, the shader allows to toggle rounding for each corner.
+    */
+
     const auto finalBlurTexture = GLTexture::allocate(textureFormat, backgroundRect.size());
     finalBlurTexture->setFilter(GL_LINEAR);
     finalBlurTexture->setWrapMode(GL_CLAMP_TO_EDGE);

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -677,6 +677,9 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         return;
     }
 
+    float topCornerRadius = m_topCornerRadius * viewport.scale();
+    float bottomCornerRadius = m_bottomCornerRadius * viewport.scale();
+
     // Check whether the effective blur shape contains corners that need to be rounded.
     bool roundTopLeftCorner = false;
     bool roundTopRightCorner = false;
@@ -687,18 +690,18 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     if (!isMaximized || m_roundCornersOfMaximizedWindows) {
         const auto windowGeometry = w->frameGeometry();
         for (const QRectF &rect : effectiveShape) {
-            if (m_topCornerRadius && (!w->decoration() || (w->decoration() && m_blurDecorations))) {
-                const QRectF topLeftCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x(), windowGeometry.y(), m_topCornerRadius, m_topCornerRadius)),data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
+            if (topCornerRadius && (!w->decoration() || (w->decoration() && m_blurDecorations))) {
+                const QRectF topLeftCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x(), windowGeometry.y(), topCornerRadius, topCornerRadius)),data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
                 roundTopLeftCorner = roundTopLeftCorner || rect.intersects(topLeftCorner);
 
-                const QRectF topRightCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x() + windowGeometry.width() - m_topCornerRadius, windowGeometry.y(),m_topCornerRadius, m_topCornerRadius)), data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
+                const QRectF topRightCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x() + windowGeometry.width() - topCornerRadius, windowGeometry.y(),topCornerRadius, topCornerRadius)), data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
                 roundTopRightCorner = roundTopRightCorner || rect.intersects(topRightCorner);
             }
-            if (m_bottomCornerRadius) {
-                const QRectF bottomLeftCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x(), windowGeometry.y() + windowGeometry.height() - m_bottomCornerRadius,m_bottomCornerRadius,m_bottomCornerRadius)),data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
+            if (bottomCornerRadius) {
+                const QRectF bottomLeftCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x(), windowGeometry.y() + windowGeometry.height() - bottomCornerRadius,bottomCornerRadius,bottomCornerRadius)),data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
                 roundBottomLeftCorner = roundBottomLeftCorner || rect.intersects(bottomLeftCorner);
 
-                const QRectF bottomRightCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x() + windowGeometry.width() - m_bottomCornerRadius,windowGeometry.y() + windowGeometry.height() - m_bottomCornerRadius,m_bottomCornerRadius, m_bottomCornerRadius)), data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
+                const QRectF bottomRightCorner = snapToPixelGridF(scaledRect(effectiveBlurRegion(QRegion(QRect(windowGeometry.x() + windowGeometry.width() - bottomCornerRadius,windowGeometry.y() + windowGeometry.height() - bottomCornerRadius,bottomCornerRadius, bottomCornerRadius)), data).boundingRect(), viewport.scale())).translated(-deviceBackgroundRect.topLeft());
                 roundBottomRightCorner = roundBottomRightCorner || rect.intersects(bottomRightCorner);
             }
         }
@@ -1028,8 +1031,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         m_roundedCorners.shader->setUniform(m_roundedCorners.roundTopRightCornerLocation, roundBottomRightCorner);
         m_roundedCorners.shader->setUniform(m_roundedCorners.roundBottomLeftCornerLocation, roundTopLeftCorner);
         m_roundedCorners.shader->setUniform(m_roundedCorners.roundBottomRightCornerLocation, roundTopRightCorner);
-        m_roundedCorners.shader->setUniform(m_roundedCorners.topCornerRadiusLocation, m_bottomCornerRadius);
-        m_roundedCorners.shader->setUniform(m_roundedCorners.bottomCornerRadiusLocation, m_topCornerRadius);
+        m_roundedCorners.shader->setUniform(m_roundedCorners.topCornerRadiusLocation, bottomCornerRadius);
+        m_roundedCorners.shader->setUniform(m_roundedCorners.bottomCornerRadiusLocation, topCornerRadius);
         m_roundedCorners.shader->setUniform(m_roundedCorners.antialiasingLocation, m_roundedCornersAntialiasing);
         m_roundedCorners.shader->setUniform(m_roundedCorners.regionSizeLocation, QVector2D(deviceBackgroundRect.width(), deviceBackgroundRect.height()));
         m_roundedCorners.shader->setUniform(m_roundedCorners.mvpMatrixLocation, projectionMatrix);

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -792,9 +792,13 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     bool roundBottomRightCorner = false;
     if (hasRoundedCorners) {
         if (w->isDock()) {
-            // TODO Add option to toggle rounding for the dock
-            roundTopLeftCorner = roundTopRightCorner = topCornerRadius;
-            roundBottomLeftCorner = roundBottomRightCorner = bottomCornerRadius;
+            // Only round floating panels. If the pixel at (0, height / 2) for horizontal panels and (width / 2, 0)
+            // for vertical panels doesn't belong to the blur region, the panel is most likely floating. The (0,0)
+            // pixel may be outside the blur region if the panel can float but isn't at the moment.
+            if (!blurRegion(w).intersects(QRect(0, w->height() / 2, 1, 1)) && !blurRegion(w).intersects(QRect(w->width() / 2, 0, 1, 1))) {
+                roundTopLeftCorner = roundTopRightCorner = topCornerRadius;
+                roundBottomLeftCorner = roundBottomRightCorner = bottomCornerRadius;
+            }
         } else {
             // Ensure the blur region corners touch the window corners before rounding them.
             const QRect windowGeometry = w->frameGeometry().toRect();

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1057,6 +1057,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         vbo->draw(GL_TRIANGLES, 6, vertexCount);
 
         glDisable(GL_BLEND);
+        glActiveTexture(GL_TEXTURE0);
         renderInfo.textures[0]->unbind();
         finalBlurTexture->unbind();
         ShaderManager::instance()->popShader();

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -418,7 +418,7 @@ void BlurEffect::generateRoundedCornerMasks(int radius, QRegion &left, QRegion &
     m_roundedCorners.shader->setUniform(m_roundedCorners.roundTopRightCornerLocation, false);
     m_roundedCorners.shader->setUniform(m_roundedCorners.roundBottomLeftCornerLocation, true);
     m_roundedCorners.shader->setUniform(m_roundedCorners.roundBottomRightCornerLocation, true);
-    m_roundedCorners.shader->setUniform(m_roundedCorners.topCornerRadiusLocation, 0);
+    m_roundedCorners.shader->setUniform(m_roundedCorners.topCornerRadiusLocation, static_cast<float>(0));
     m_roundedCorners.shader->setUniform(m_roundedCorners.bottomCornerRadiusLocation, radius);
     m_roundedCorners.shader->setUniform(m_roundedCorners.antialiasingLocation, static_cast<float>(0));
     m_roundedCorners.shader->setUniform(m_roundedCorners.regionSizeLocation, QVector2D(size, size));

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1150,13 +1150,9 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
                     projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
                 }
 
-                const QVector2D textureStartPosition = hasAntialiasedRoundedCorners
-                    ? QVector2D(deviceBackgroundRect.x() * 2, std::abs(deviceBackgroundRect.height() - deviceBackgroundRect.y() * 2))
-                    : QVector2D(deviceBackgroundRect.topLeft());
-
                 m_noisePass.shader->setUniform(m_noisePass.mvpMatrixLocation, projectionMatrix);
                 m_noisePass.shader->setUniform(m_noisePass.noiseTextureSizeLocation, QVector2D(noiseTexture->width(), noiseTexture->height()));
-                m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, textureStartPosition);
+                m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, QVector2D(deviceBackgroundRect.topLeft()));
 
                 noiseTexture->bind();
 

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1150,9 +1150,13 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
                     projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
                 }
 
+                const QVector2D textureStartPosition = hasAntialiasedRoundedCorners
+                    ? QVector2D(deviceBackgroundRect.x() * 2, std::abs(deviceBackgroundRect.height() - deviceBackgroundRect.y() * 2))
+                    : QVector2D(deviceBackgroundRect.topLeft());
+
                 m_noisePass.shader->setUniform(m_noisePass.mvpMatrixLocation, projectionMatrix);
                 m_noisePass.shader->setUniform(m_noisePass.noiseTextureSizeLocation, QVector2D(noiseTexture->width(), noiseTexture->height()));
-                m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, QVector2D(deviceBackgroundRect.topLeft()));
+                m_noisePass.shader->setUniform(m_noisePass.texStartPosLocation, textureStartPosition);
 
                 noiseTexture->bind();
 

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -103,6 +103,7 @@ BlurEffect::BlurEffect()
         m_texturePass.mvpMatrixLocation = m_texturePass.shader->uniformLocation("modelViewProjectionMatrix");
         m_texturePass.textureSizeLocation = m_texturePass.shader->uniformLocation("textureSize");
         m_texturePass.texStartPosLocation = m_texturePass.shader->uniformLocation("texStartPos");
+        m_texturePass.regionSizeLocation = m_texturePass.shader->uniformLocation("regionSize");
     }
 
     m_roundedCorners.shader = ShaderManager::instance()->generateShaderFromFile(ShaderTrait::MapTexture,
@@ -865,7 +866,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
         m_texturePass.shader->setUniform(m_texturePass.mvpMatrixLocation, projectionMatrix);
         m_texturePass.shader->setUniform(m_texturePass.textureSizeLocation, QVector2D(m_texturePass.texture.get()->width(), m_texturePass.texture.get()->height()));
-        m_texturePass.shader->setUniform(m_texturePass.texStartPosLocation, QVector2D(0, 0));
+        m_texturePass.shader->setUniform(m_texturePass.texStartPosLocation, QVector2D(backgroundRect.x(), backgroundRect.y()));
+        m_texturePass.shader->setUniform(m_texturePass.regionSizeLocation, QVector2D(backgroundRect.width(), backgroundRect.height()));
 
         m_texturePass.texture.get()->bind();
 
@@ -1029,7 +1031,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         m_roundedCorners.shader->setUniform(m_roundedCorners.topCornerRadiusLocation, m_bottomCornerRadius);
         m_roundedCorners.shader->setUniform(m_roundedCorners.bottomCornerRadiusLocation, m_topCornerRadius);
         m_roundedCorners.shader->setUniform(m_roundedCorners.antialiasingLocation, m_roundedCornersAntialiasing);
-        m_roundedCorners.shader->setUniform(m_roundedCorners.regionSizeLocation, QVector2D(deviceBackgroundRect.size().width(), deviceBackgroundRect.size().height()));
+        m_roundedCorners.shader->setUniform(m_roundedCorners.regionSizeLocation, QVector2D(deviceBackgroundRect.width(), deviceBackgroundRect.height()));
         m_roundedCorners.shader->setUniform(m_roundedCorners.mvpMatrixLocation, projectionMatrix);
 
         glUniform1i(m_roundedCorners.beforeBlurTextureLocation, 0);

--- a/src/blur.h
+++ b/src/blur.h
@@ -88,14 +88,14 @@ private:
     GLTexture *ensureNoiseTexture();
 
     /*
-     * @returns An array containing rounded corner masks for the given screen scale. If no masks exist for the given screen scale,
-     * they will be generated.
+     * @returns An array containing rounded corner masks for the given screen scale and radii. If no masks exist, they
+     * will be generated.
      */
     std::array<QRegion, 4> roundedCorners(int topCornerRadius, int bottomCornerRadius, qreal scale);
 
     /*
-     * Generates rounded corner masks for the left and right corner for the given radius.
-     * @param top Whether TODO
+     * Generates rounded corner masks for the left and right corner of the given radius.
+     * @param top Whether the corners belong to the top part of the window.
      */
     void generateRoundedCornerMasks(int radius, QRegion &left, QRegion &right, bool top) const;
 

--- a/src/blur.h
+++ b/src/blur.h
@@ -88,16 +88,10 @@ private:
     GLTexture *ensureNoiseTexture();
 
     /*
-     * @param regionScale How much to scale the blur region. This parameter should be 1 if the region is rounded.
-     * @returns The area to be blurred. It's possible that all of it will be clipped.
-     */
-    QList<QRectF> effectiveBlurShape(const QRect &backgroundRect, const QRect &deviceBackgroundRect, const QRegion &paintRegion, const QRegion &blurRegion, qreal screenScale, qreal regionScale) const;
-
-    /*
      * @returns An array containing rounded corner masks for the given screen scale. If no masks exist for the given screen scale,
      * they will be generated.
      */
-    std::array<QRegion, 4> roundedCorners(qreal scale);
+    std::array<QRegion, 4> roundedCorners(int topCornerRadius, int bottomCornerRadius, qreal scale);
 
     /*
      * Generates rounded corner masks for the left and right corner for the given radius.
@@ -182,10 +176,6 @@ private:
     bool m_blurNonMatching;
     bool m_blurDecorations;
     bool m_transparentBlur;
-    int m_topCornerRadius;
-    int m_bottomCornerRadius;
-    float m_roundedCornersAntialiasing;
-    bool m_roundCornersOfMaximizedWindows;
     bool m_blurMenus;
     bool m_blurDocks;
     bool m_paintAsTranslucent;
@@ -194,11 +184,17 @@ private:
 
     bool m_hasValidFakeBlurTexture;
 
+    int m_windowTopCornerRadius;
+    int m_windowBottomCornerRadius;
+    int m_menuCornerRadius;
+    int m_dockCornerRadius;
+    float m_roundedCornersAntialiasing;
+    bool m_roundCornersOfMaximizedWindows;
     int m_cornerRadiusOffset;
 
     // Corner masks where the key is the screen scale and the value is an array of the masks
     // (top left, top right, bottom left, bottom right). Used for rounding the blur region.
-    std::unordered_map<qreal, std::array<QRegion, 4>> m_corners;
+    std::map<const std::tuple<int, int, qreal>, std::array<QRegion, 4>> m_corners;
 
     struct OffsetStruct
     {

--- a/src/blur.h
+++ b/src/blur.h
@@ -124,6 +124,7 @@ private:
         int mvpMatrixLocation;
         int textureSizeLocation;
         int texStartPosLocation;
+        int regionSizeLocation;
 
         std::unique_ptr<GLTexture> texture;
     } m_texturePass;

--- a/src/blur.h
+++ b/src/blur.h
@@ -143,7 +143,6 @@ private:
         int antialiasingLocation;
 
         int regionSizeLocation;
-        int offsetLocation;
 
         int beforeBlurTextureLocation;
         int afterBlurTextureLocation;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -28,11 +28,14 @@ class3</default>
         <entry name="TransparentBlur" type="Bool">
             <default>true</default>
         </entry>
-        <entry name="TopCornerRadius" type="Int">
-            <default>0</default>
+        <entry name="TopCornerRadius" type="Double">
+            <default>0.0</default>
         </entry>
-        <entry name="BottomCornerRadius" type="Int">
-            <default>0</default>
+        <entry name="BottomCornerRadius" type="Double">
+            <default>0.0</default>
+        </entry>
+        <entry name="RoundedCornersAntialiasing" type="Double">
+            <default>1.0</default>
         </entry>
         <entry name="RoundCornersOfMaximizedWindows" type="Bool">
             <default>false</default>

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -28,11 +28,11 @@ class3</default>
         <entry name="TransparentBlur" type="Bool">
             <default>true</default>
         </entry>
-        <entry name="TopCornerRadius" type="Double">
-            <default>0.0</default>
+        <entry name="TopCornerRadius" type="Int">
+            <default>0</default>
         </entry>
-        <entry name="BottomCornerRadius" type="Double">
-            <default>0.0</default>
+        <entry name="BottomCornerRadius" type="Int">
+            <default>0</default>
         </entry>
         <entry name="RoundedCornersAntialiasing" type="Double">
             <default>1.0</default>

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -34,6 +34,12 @@ class3</default>
         <entry name="BottomCornerRadius" type="Int">
             <default>0</default>
         </entry>
+        <entry name="MenuCornerRadius" type="Int">
+            <default>0</default>
+        </entry>
+        <entry name="DockCornerRadius" type="Int">
+            <default>0</default>
+        </entry>
         <entry name="RoundedCornersAntialiasing" type="Double">
             <default>1.0</default>
         </entry>

--- a/src/blur.qrc
+++ b/src/blur.qrc
@@ -4,6 +4,8 @@
   <file>shaders/downsample_core.frag</file>
   <file>shaders/noise.frag</file>
   <file>shaders/noise_core.frag</file>
+  <file>shaders/roundedcorners.frag</file>
+  <file>shaders/roundedcorners_core.frag</file>
   <file>shaders/texture.frag</file>
   <file>shaders/texture_core.frag</file>
   <file>shaders/upsample.frag</file>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -321,7 +321,7 @@
          <item>
           <widget class="QLabel">
            <property name="text">
-            <string>Top corner radius</string>
+            <string>Window top corner radius</string>
            </property>
           </widget>
          </item>
@@ -339,7 +339,7 @@
          <item>
           <widget class="QLabel">
            <property name="text">
-            <string>Bottom corner radius</string>
+            <string>Window bottom corner radius</string>
            </property>
           </widget>
          </item>
@@ -357,7 +357,43 @@
          <item>
           <widget class="QLabel">
            <property name="text">
-            <string>Antialiasing</string>
+            <string>Menu corner radius</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="kcfg_MenuCornerRadius">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel">
+           <property name="text">
+            <string>Dock corner radius</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="kcfg_DockCornerRadius">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel">
+           <property name="text">
+            <string>Anti-aliasing</string>
            </property>
           </widget>
          </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -326,7 +326,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="kcfg_TopCornerRadius">
+          <widget class="QSpinBox" name="kcfg_TopCornerRadius">
            <property name="minimum">
             <number>0</number>
            </property>
@@ -344,7 +344,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="kcfg_BottomCornerRadius">
+          <widget class="QSpinBox" name="kcfg_BottomCornerRadius">
            <property name="minimum">
             <number>0</number>
            </property>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -326,7 +326,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="kcfg_TopCornerRadius">
+          <widget class="QDoubleSpinBox" name="kcfg_TopCornerRadius">
            <property name="minimum">
             <number>0</number>
            </property>
@@ -344,7 +344,25 @@
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="kcfg_BottomCornerRadius">
+          <widget class="QDoubleSpinBox" name="kcfg_BottomCornerRadius">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel">
+           <property name="text">
+            <string>Antialiasing</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="kcfg_RoundedCornersAntialiasing">
            <property name="minimum">
             <number>0</number>
            </property>

--- a/src/shaders/roundedcorners.frag
+++ b/src/shaders/roundedcorners.frag
@@ -1,0 +1,43 @@
+// Modified version of https://www.shadertoy.com/view/ldfSDj
+
+uniform bool roundTopLeftCorner;
+uniform bool roundTopRightCorner;
+uniform bool roundBottomLeftCorner;
+uniform bool roundBottomRightCorner;
+
+uniform float topCornerRadius;
+uniform float bottomCornerRadius;
+
+uniform float antialiasing;
+
+uniform vec2 regionSize;
+uniform vec2 offset;
+
+uniform sampler2D beforeBlurTexture;
+uniform sampler2D afterBlurTexture;
+
+varying vec2 uv;
+
+float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
+{
+    float radius = 0.0;
+    if ((fragCoord.y <= topCornerRadius)
+    && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
+    || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
+        radius = topCornerRadius;
+    } else if ((fragCoord.y >= regionSize.y - bottomCornerRadius)
+    && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
+    || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
+        radius = bottomCornerRadius;
+    }
+
+    return length(max(abs(p) - b + radius, 0.0)) - radius;
+}
+
+void main(void)
+{
+    vec2 halfRegionSize = regionSize * 0.5;
+    vec2 textureLocation = (gl_FragCoord.xy - offset) / regionSize.xy;
+    float box = udRoundBox(-offset + gl_FragCoord.xy - halfRegionSize, halfRegionSize, gl_FragCoord.xy - offset);
+    gl_FragColor = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+}

--- a/src/shaders/roundedcorners.frag
+++ b/src/shaders/roundedcorners.frag
@@ -5,8 +5,8 @@ uniform bool roundTopRightCorner;
 uniform bool roundBottomLeftCorner;
 uniform bool roundBottomRightCorner;
 
-uniform float topCornerRadius;
-uniform float bottomCornerRadius;
+uniform int topCornerRadius;
+uniform int bottomCornerRadius;
 
 uniform float antialiasing;
 
@@ -40,5 +40,14 @@ void main(void)
     vec2 halfRegionSize = regionSize * 0.5;
     vec2 fragCoord = uv * regionSize;
     float box = udRoundBox(fragCoord - halfRegionSize, halfRegionSize, fragCoord);
-    gl_FragColor = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+
+    // If antialiasing is 0, the shader will be used to generate corner masks.
+    vec3 foreground = vec3(1.0, 1.0, 1.0);
+    vec3 background = vec3(0.0, 0.0, 0.0);
+    if (antialiasing > 0.0) {
+        foreground = texture2D(afterBlurTexture, uv).rgb;
+        background = texture2D(beforeBlurTexture, uv).rgb;
+    }
+
+    gl_FragColor = vec4(mix(foreground, background, smoothstep(0.0, antialiasing, box)), 1.0);
 }

--- a/src/shaders/roundedcorners.frag
+++ b/src/shaders/roundedcorners.frag
@@ -11,7 +11,6 @@ uniform float bottomCornerRadius;
 uniform float antialiasing;
 
 uniform vec2 regionSize;
-uniform vec2 offset;
 
 uniform sampler2D beforeBlurTexture;
 uniform sampler2D afterBlurTexture;
@@ -22,12 +21,12 @@ float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
 {
     float radius = 0.0;
     if ((fragCoord.y <= topCornerRadius)
-    && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
-    || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
+        && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
+            || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
         radius = topCornerRadius;
     } else if ((fragCoord.y >= regionSize.y - bottomCornerRadius)
-    && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
-    || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
+        && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
+            || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
         radius = bottomCornerRadius;
     }
 
@@ -37,7 +36,7 @@ float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
 void main(void)
 {
     vec2 halfRegionSize = regionSize * 0.5;
-    vec2 textureLocation = (gl_FragCoord.xy - offset) / regionSize.xy;
-    float box = udRoundBox(-offset + gl_FragCoord.xy - halfRegionSize, halfRegionSize, gl_FragCoord.xy - offset);
-    gl_FragColor = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+    vec2 fragCoord = uv * regionSize;
+    float box = udRoundBox(fragCoord - halfRegionSize, halfRegionSize, fragCoord);
+    gl_FragCoord = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
 }

--- a/src/shaders/roundedcorners.frag
+++ b/src/shaders/roundedcorners.frag
@@ -24,13 +24,15 @@ float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
         && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
             || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
         radius = topCornerRadius;
+        p.y -= radius;
     } else if ((fragCoord.y >= regionSize.y - bottomCornerRadius)
         && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
             || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
         radius = bottomCornerRadius;
+        p.y += radius;
     }
 
-    return length(max(abs(p) - b + radius, 0.0)) - radius;
+    return length(max(abs(p) - (b + vec2(0.0, radius)) + radius, 0.0)) - radius;
 }
 
 void main(void)

--- a/src/shaders/roundedcorners.frag
+++ b/src/shaders/roundedcorners.frag
@@ -38,5 +38,5 @@ void main(void)
     vec2 halfRegionSize = regionSize * 0.5;
     vec2 fragCoord = uv * regionSize;
     float box = udRoundBox(fragCoord - halfRegionSize, halfRegionSize, fragCoord);
-    gl_FragCoord = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+    gl_FragColor = vec4(mix(texture2D(afterBlurTexture, uv).rgb, texture2D(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
 }

--- a/src/shaders/roundedcorners_core.frag
+++ b/src/shaders/roundedcorners_core.frag
@@ -1,0 +1,47 @@
+#version 140
+
+// Modified version of https://www.shadertoy.com/view/ldfSDj
+
+uniform bool roundTopLeftCorner;
+uniform bool roundTopRightCorner;
+uniform bool roundBottomLeftCorner;
+uniform bool roundBottomRightCorner;
+
+uniform float topCornerRadius;
+uniform float bottomCornerRadius;
+
+uniform float antialiasing;
+
+uniform vec2 regionSize;
+uniform vec2 offset;
+
+uniform sampler2D beforeBlurTexture;
+uniform sampler2D afterBlurTexture;
+
+in vec2 uv;
+
+out vec4 fragColor;
+
+float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
+{
+    float radius = 0.0;
+    if ((fragCoord.y <= topCornerRadius)
+        && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
+            || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
+        radius = topCornerRadius;
+    } else if ((fragCoord.y >= regionSize.y - bottomCornerRadius)
+        && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
+            || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
+        radius = bottomCornerRadius;
+    }
+
+    return length(max(abs(p) - b + radius, 0.0)) - radius;
+}
+
+void main(void)
+{
+    vec2 halfRegionSize = regionSize * 0.5;
+    vec2 textureLocation = (gl_FragCoord.xy - offset) / regionSize.xy;
+    float box = udRoundBox(-offset + gl_FragCoord.xy - halfRegionSize, halfRegionSize, gl_FragCoord.xy - offset);
+    fragColor = vec4(mix(texture(afterBlurTexture, uv).rgb, texture(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+}

--- a/src/shaders/roundedcorners_core.frag
+++ b/src/shaders/roundedcorners_core.frag
@@ -7,8 +7,8 @@ uniform bool roundTopRightCorner;
 uniform bool roundBottomLeftCorner;
 uniform bool roundBottomRightCorner;
 
-uniform float topCornerRadius;
-uniform float bottomCornerRadius;
+uniform int topCornerRadius;
+uniform int bottomCornerRadius;
 
 uniform float antialiasing;
 
@@ -44,5 +44,14 @@ void main(void)
     vec2 halfRegionSize = regionSize * 0.5;
     vec2 fragCoord = uv * regionSize;
     float box = udRoundBox(fragCoord - halfRegionSize, halfRegionSize, fragCoord);
-    fragColor = vec4(mix(texture(afterBlurTexture, uv).rgb, texture(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
+
+    // If antialiasing is 0, the shader will be used to generate corner masks.
+    vec3 foreground = vec3(1.0, 1.0, 1.0);
+    vec3 background = vec3(0.0, 0.0, 0.0);
+    if (antialiasing > 0.0) {
+        foreground = texture(afterBlurTexture, uv).rgb;
+        background = texture(beforeBlurTexture, uv).rgb;
+    }
+
+    fragColor = vec4(mix(foreground, background, smoothstep(0.0, antialiasing, box)), 1.0);
 }

--- a/src/shaders/roundedcorners_core.frag
+++ b/src/shaders/roundedcorners_core.frag
@@ -28,13 +28,15 @@ float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
         && ((roundTopLeftCorner && fragCoord.x <= topCornerRadius)
             || (roundTopRightCorner && fragCoord.x >= regionSize.x - topCornerRadius))) {
         radius = topCornerRadius;
+        p.y -= radius;
     } else if ((fragCoord.y >= regionSize.y - bottomCornerRadius)
         && ((roundBottomLeftCorner && fragCoord.x <= bottomCornerRadius)
             || (roundBottomRightCorner && fragCoord.x >= regionSize.x - bottomCornerRadius))) {
         radius = bottomCornerRadius;
+        p.y += radius;
     }
 
-    return length(max(abs(p) - b + radius, 0.0)) - radius;
+    return length(max(abs(p) - (b + vec2(0.0, radius)) + radius, 0.0)) - radius;
 }
 
 void main(void)

--- a/src/shaders/roundedcorners_core.frag
+++ b/src/shaders/roundedcorners_core.frag
@@ -13,7 +13,6 @@ uniform float bottomCornerRadius;
 uniform float antialiasing;
 
 uniform vec2 regionSize;
-uniform vec2 offset;
 
 uniform sampler2D beforeBlurTexture;
 uniform sampler2D afterBlurTexture;
@@ -41,7 +40,7 @@ float udRoundBox(vec2 p, vec2 b, vec2 fragCoord)
 void main(void)
 {
     vec2 halfRegionSize = regionSize * 0.5;
-    vec2 textureLocation = (gl_FragCoord.xy - offset) / regionSize.xy;
-    float box = udRoundBox(-offset + gl_FragCoord.xy - halfRegionSize, halfRegionSize, gl_FragCoord.xy - offset);
+    vec2 fragCoord = uv * regionSize;
+    float box = udRoundBox(fragCoord - halfRegionSize, halfRegionSize, fragCoord);
     fragColor = vec4(mix(texture(afterBlurTexture, uv).rgb, texture(beforeBlurTexture, uv).rgb, smoothstep(0.0, antialiasing, box)), 1.0);
 }

--- a/src/shaders/texture.frag
+++ b/src/shaders/texture.frag
@@ -1,12 +1,12 @@
 uniform sampler2D texUnit;
 uniform vec2 textureSize;
 uniform vec2 texStartPos;
+uniform vec2 regionSize;
 
 varying vec2 uv;
 
 void main(void)
 {
-    vec2 tex = vec2((texStartPos.xy + gl_FragCoord.xy) / textureSize);
-
+    vec2 tex = (texStartPos.xy + vec2(uv.x, 1.0 - uv.y) * regionSize) / textureSize;
     gl_FragColor = vec4(texture2D(texUnit, tex).rgb, 0);
 }

--- a/src/shaders/texture_core.frag
+++ b/src/shaders/texture_core.frag
@@ -3,6 +3,7 @@
 uniform sampler2D texUnit;
 uniform vec2 textureSize;
 uniform vec2 texStartPos;
+uniform vec2 regionSize;
 
 in vec2 uv;
 
@@ -10,7 +11,6 @@ out vec4 fragColor;
 
 void main(void)
 {
-    vec2 tex = vec2((texStartPos.xy + gl_FragCoord.xy) / textureSize);
-
+    vec2 tex = (texStartPos.xy + vec2(uv.x, 1.0 - uv.y) * regionSize) / textureSize;
     fragColor = vec4(texture(texUnit, tex).rgb, 0);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <effect/globals.h>
+#include "core/pixelgrid.h"
+#include <QRegion>
+
+namespace KWin
+{
+
+inline QRegion scaledRegion(const QRegion &region, qreal scale)
+{
+    QRegion scaledRegion;
+    for (const QRect &rect : region) {
+        scaledRegion += QRect(std::round(rect.x() * scale), std::round(rect.y() * scale), std::round(rect.width() * scale), std::round(rect.height() * scale));
+    }
+
+    return scaledRegion;
+}
+
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,4 +16,17 @@ inline QRegion scaledRegion(const QRegion &region, qreal scale)
     return scaledRegion;
 }
 
+inline bool isMenu(const EffectWindow *w)
+{
+    return w->isMenu() || w->isDropdownMenu() || w->isPopupMenu() || w->isPopupWindow();
+}
+
+inline bool isDockFloating(const EffectWindow *dock, const QRegion blurRegion)
+{
+    // If the pixel at (0, height / 2) for horizontal panels and (width / 2, 0) for vertical panels doesn't belong to
+    // the blur region, the dock is most likely floating. The (0,0) pixel may be outside the blur region if the dock
+    // can float but isn't at the moment.
+    return !blurRegion.intersects(QRect(0, dock->height() / 2, 1, 1)) && !blurRegion.intersects(QRect(dock->width() / 2, 0, 1, 1));
+}
+
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,7 +2,6 @@
 
 #include <effect/globals.h>
 #include "core/pixelgrid.h"
-#include <QRegion>
 
 namespace KWin
 {
@@ -11,7 +10,7 @@ inline QRegion scaledRegion(const QRegion &region, qreal scale)
 {
     QRegion scaledRegion;
     for (const QRect &rect : region) {
-        scaledRegion += QRect(std::round(rect.x() * scale), std::round(rect.y() * scale), std::round(rect.width() * scale), std::round(rect.height() * scale));
+        scaledRegion += snapToPixelGridF(scaledRect(QRectF(rect), scale)).toRect();
     }
 
     return scaledRegion;


### PR DESCRIPTION
This is a rewrite of the rounded corners implementation, which has much better-looking corners. There's probably a better way to do it, but for now that's the simplest and most efficient way of doing it that I can implement myself.

The corner radiuses are also now decimal values.

# Comparison
The pictures were made in the worst possible situation: maximum blur strength with the corner being on a darker surface right next to a bright one.

## Blur only (15px radius)
### Before
![1](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/114a379d-598f-43b5-8efe-72f38926e0d6)

### After
No antialiasing:
![2](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/1c759d68-5868-40d7-8f97-fd1c5ad30f92)
0,5 antialiasing:
![3](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/d0b8c54a-26a3-4cc3-82e1-c1b47ecd4d51)

## With window-rounding effects (15px radius)
### KDE-Rounded-Corners 
17px blur radius with 1 antialiasing
![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/bdd2247a-14ad-4c57-9a54-29a6d47025a9)
Couldn't get it to match perfectly, but it's definitely better than before.

### LightlyShaders 
14,75px blur radius with 0,5 antialiasing
![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/cc198e95-fa87-4254-996e-e6dcbcf6bc97)
Looks perfect.

# To do
- [x] Blur is very often painted in the wrong position
- [x] Corners may not be rounded if *Blur window decorations as well* is disabled
- [x] Don't use the rounded corners shader to paint areas that don't intersect with any of the corners
- [x] Fake blur doesn't work properly
- [x] Very strong artifacts when using the *Colorblindness Correction* or *Invert* effects
- [x] Texture behind panels behaves in a weird way when using the *Background Contrast* effect
- [x] The shader may not work properly with small regions
- [x] Regions behind rounded corners aren't marked as translucent
- [x] Round corners using the blur region mask method when antialiasing is set to 0
- [x] Korners when using scaling on Wayland, caused by the texture size not being multiplied by the screen scale
- [x] Corners aren't rounded when the window is scaled (for example during the closing animation)
- [ ] Noise texture doesn't move along the X axis anymore
