### PR TITLE
Fix for kwin's master branch

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -425,7 +425,7 @@ QRegion BlurEffect::decorationBlurRegion(const EffectWindow *w) const
         return QRegion();
     }
 
-    QRegion decorationRegion = QRegion(w->decoration()->rect()) - w->decorationInnerRect().toRect();
+    QRegion decorationRegion = QRegion(w->decoration()->rect()) - w->contentsRect().toRect();
     //! we return only blurred regions that belong to decoration region
     return decorationRegion.intersected(w->decoration()->blurRegion());
 }
@@ -446,7 +446,7 @@ QRegion BlurEffect::blurRegion(EffectWindow *w) const
                 if (frame.has_value()) {
                     region = frame.value();
                 }
-                region += content->translated(w->contentsRect().topLeft().toPoint()) & w->decorationInnerRect().toRect();
+                region += content->translated(w->contentsRect().topLeft().toPoint()) & w->contentsRect().toRect();
             }
         } else if (frame.has_value()) {
             region = frame.value();


### PR DESCRIPTION
decorationInnerRect [was removed](https://invent.kde.org/plasma/kwin/-/commit/8542c2003014930c842f893cff956a32f92b4772)

Haven't tested with 6.1 but I believe it should be backwards-compatible