### PR TITLE
rename project to KWin Better Blur (kwin-better-blur)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-project(forceblur)
+project(kwin_better_blur)
 set(PROJECT_VERSION "1.3.1")
 set(PROJECT_VERSION_MAJOR 0)
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Fixes for blur-related Plasma bugs that haven't been patched yet.
 <details>
   <summary>NixOS (flakes)</summary>
   <br>
-  
+
   ``flake.nix``:
   ```nix
   {
     inputs = {
       nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  
+
       kwin-effects-forceblur = {
         url = "github:taj-ny/kwin-effects-forceblur";
         inputs.nixpkgs.follows = "nixpkgs";
@@ -36,10 +36,10 @@ Fixes for blur-related Plasma bugs that haven't been patched yet.
     };
   }
   ```
-  
+
   ```nix
   { inputs, pkgs, ... }:
-  
+
   {
     environment.systemPackages = [
       inputs.kwin-effects-forceblur.packages.${pkgs.system}.default
@@ -107,7 +107,7 @@ sudo make install
 Remove the *build* directory when rebuilding the effect.
 
 # Usage
-> [!NOTE]  
+> [!NOTE]
 > If the effect stops working after a system upgrade, you will need to rebuild it.
 
 This effect will conflict with the stock blur effect and any other forks of it.
@@ -115,10 +115,10 @@ This effect will conflict with the stock blur effect and any other forks of it.
 1. Install the plugin.
 2. Open the *Desktop Effects* page in *System Settings*.
 3. Disable any blur effects.
-4. Enable the *Force Blur* effect.
+4. Enable the *Better Blur* effect.
 
 For more detailed descriptions of some options, check out [this wiki page](https://github.com/taj-ny/kwin-effects-forceblur/wiki/Configuration).
-   
+
 ### Window transparency
 The window needs to be translucent in order for the blur to be visible. This can be done in multiple ways:
 - Use a transparent theme for the program if it supports it

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # KWin Better Blur [![AUR Version](https://img.shields.io/aur/version/kwin-effects-forceblur)](https://aur.archlinux.org/packages/kwin-effects-forceblur)
-Better Blur (formerly kwin-effects-forceblur) is a fork of the KWin Blur effect with several improvements and bug fixes.
+Better Blur (formerly kwin-effects-forceblur) is a fork the KWin Blur effect for KDE Plasma 6 with additional features and bug fixes.
 
 Latest features are available on the ``develop`` branch.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# kwin-effects-forceblur [![AUR Version](https://img.shields.io/aur/version/kwin-effects-forceblur)](https://aur.archlinux.org/packages/kwin-effects-forceblur)
-Kwin-effects-forceblur (name subject to change) is a fork of the KWin Blur effect for KDE Plasma 6 with several improvements and bug fixes.
+# KWin Better Blur [![AUR Version](https://img.shields.io/aur/version/kwin-effects-forceblur)](https://aur.archlinux.org/packages/kwin-effects-forceblur)
+Better Blur (formerly kwin-effects-forceblur) is a fork of the KWin Blur effect with several improvements and bug fixes.
 
 Latest features are available on the ``develop`` branch.
 
@@ -110,7 +110,7 @@ Remove the *build* directory when rebuilding the effect.
 > [!NOTE]  
 > If the effect stops working after a system upgrade, you will need to rebuild it.
 
-Since kwin-effects-forceblur is a fork, you need to disable the stock blur effect and any other blur effects you may be using.
+This effect will conflict with the stock blur effect and any other forks of it.
 
 1. Install the plugin.
 2. Open the *Desktop Effects* page in *System Settings*.

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718160348,
-        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Fork of the KWin Blur effect for KDE Plasma 6 with force blur and more";
+  description = "Fork of the KWin Blur effect for KDE Plasma 6 with additional features (including force blur) and bug fixes";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A fork of the KWin Blur effect for KDE Plasma 6 with the ability to blur any window on Wayland and X11";
+  description = "Fork of the KWin Blur effect for KDE Plasma 6 with force blur and more";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/package.nix
+++ b/package.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "kwin-effects-forceblur";
+  pname = "kwin-better-blur";
   version = "1.3.1";
 
   src = ./.;
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A fork of the KWin Blur effect for KDE Plasma 6 with the ability to blur any window on Wayland and X11";
+    description = "Fork of the KWin Blur effect for KDE Plasma 6 with force blur and more";
     license = licenses.gpl3;
     homepage = "https://github.com/taj-ny/kwin-effects-forceblur";
   };

--- a/package.nix
+++ b/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "Fork of the KWin Blur effect for KDE Plasma 6 with force blur and more";
+    description = "Fork of the KWin Blur effect for KDE Plasma 6 with additional features (including force blur) and bug fixes";
     license = licenses.gpl3;
     homepage = "https://github.com/taj-ny/kwin-effects-forceblur";
   };

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -37,7 +37,7 @@
 
 #include <KDecoration2/Decoration>
 
-Q_LOGGING_CATEGORY(KWIN_BLUR, "kwin_better_blur_forceblur", QtWarningMsg)
+Q_LOGGING_CATEGORY(KWIN_BLUR, "kwin_better_blur", QtWarningMsg)
 
 static void ensureResources()
 {

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -37,7 +37,7 @@
 
 #include <KDecoration2/Decoration>
 
-Q_LOGGING_CATEGORY(KWIN_BLUR, "kwin_effect_forceblur", QtWarningMsg)
+Q_LOGGING_CATEGORY(KWIN_BLUR, "kwin_better_blur_forceblur", QtWarningMsg)
 
 static void ensureResources()
 {

--- a/src/kcm/CMakeLists.txt
+++ b/src/kcm/CMakeLists.txt
@@ -1,16 +1,16 @@
-set(kwin_forceblur_config_SRCS blur_config.cpp blur_config.h)
+set(kwin_better_blur_config_SRCS blur_config.cpp blur_config.h)
 
-ki18n_wrap_ui(kwin_forceblur_config_SRCS blur_config.ui)
-kconfig_add_kcfg_files(kwin_forceblur_config_SRCS ../blurconfig.kcfgc)
+ki18n_wrap_ui(kwin_better_blur_config_SRCS blur_config.ui)
+kconfig_add_kcfg_files(kwin_better_blur_config_SRCS ../blurconfig.kcfgc)
 
-qt_add_dbus_interface(kwin_forceblur_config_SRCS ${KWIN_EFFECTS_INTERFACE} kwineffects_interface)
+qt_add_dbus_interface(kwin_better_blur_config_SRCS ${KWIN_EFFECTS_INTERFACE} kwineffects_interface)
 
-add_library(kwin_forceblur_config MODULE ${kwin_forceblur_config_SRCS})
-target_link_libraries(kwin_forceblur_config
+add_library(kwin_better_blur_config MODULE ${kwin_better_blur_config_SRCS})
+target_link_libraries(kwin_better_blur_config
     KF6::KCMUtils
     KF6::CoreAddons
     KF6::I18n
     Qt6::DBus
 )
 
-install(TARGETS kwin_forceblur_config DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/configs)
+install(TARGETS kwin_better_blur_config DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/configs)

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -12,7 +12,7 @@
         "Description": "Blurs the background behind user-specified windows",
         "EnabledByDefault": false,
         "License": "GPL",
-        "Name": "Force Blur"
+        "Name": "Better Blur (formerly Force Blur)"
     },
-    "X-KDE-ConfigModule": "kwin_forceblur_config"
+    "X-KDE-ConfigModule": "kwin_better_blur_config"
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,7 +9,7 @@
             }
         ],
         "Category": "Appearance",
-        "Description": "Blurs the background behind user-specified windows",
+        "Description": "Fork of the KWin Blur effect for KDE Plasma 6 with force blur and more",
         "EnabledByDefault": false,
         "License": "GPL",
         "Name": "Better Blur (formerly Force Blur)"


### PR DESCRIPTION
I'm not changing the effect ID as that would disable it for everyone, so it'll remain ``forceblur`` until 2.0.