### PR TITLE
blur/fake-blur: fix various issues when using the wallpaper as the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Latest features are available on the ``develop`` branch.
 <sup>Window opacity has been set to 85% for System Settings, Dolphin and VSCodium, Firefox uses a transparent theme | [NixOS configuration](https://github.com/taj-ny/nix-config)</sup>
 
 # Features
-- Wayland support
+- X11 and Wayland support
 - Force blur
 - Rounded corners with optional anti-aliasing
-- Draw image behind windows instead of blurring (can be used with a blurred image of the wallpaper in order to achieve a very similar effect to blur but with **much** lower GPU usage)
+- Optional blur texture caching for much lower GPU usage, works best with tiling
 
 ### Bug fixes
 Fixes for blur-related Plasma bugs that haven't been patched yet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,33 +10,33 @@ Disabled:
 
 # Force blur
 ### Blur window decorations
-Whether to blur window decorations, including borders. Enable this if your window decoration doesn't support blur or you want rounded corners.
+Whether to blur window decorations, including borders. Enable this if your window decoration doesn't support blur, or you want rounded top corners.
 
-This option will override the blur region specified by the decorations.
+This option will override the blur region specified by the decoration.
 
 ### Paint windows as non-opaque
 Fixes transparency for some applications by marking their windows as transparent. This will only be done for force-blurred windows.
 
 # Fake blur
-Fake blur is mainly intended for laptop users who want longer battery life.
+When enabled, the blur texture will be cached and reused. The blurred areas of the window will be marked as opaque, resulting in KWin not painting anything behind them.
+Only one image per screen is cached at a time.
 
-If a window is entirely in front of the wallpaper, why keep blurring the same image over and over? That's a massive waste of resources.
-The effect can blur the wallpaper only once, store it in memory and paint it behind windows instead of actually blurring them.
-Because the window isn't transparent anymore, there's also no need to paint anything behind it.
+Fake blur is mainly intended for laptop users who want longer battery life while still having blur everywhere.
 
 ### Use real blur for windows that are in front of other windows
-When two windows overlap, you won't be able to see the window behind.
+By default, when two windows overlap, you won't be able to see the window behind.
 ![image](https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/e581b5c1-7b2c-41c4-b180-4da5306747e1)
 
-If this option is enabled, the effect will switch to real blur when necessary.
+If this option is enabled, the effect will automatically switch to real blur when necessary. At very high blur strengths, there may be a slight difference in the texture.
 
 https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/7bae6a16-6c78-4889-8df1-feb24005dabc
 
 ### Image source
 The image to use for fake blur.
 
-- Desktop wallpaper - A screenshot of the desktop is taken for every screen.
-- Custom - The image is read from a file and scaled for every screen without respecting the aspect ratio. Supported formats are JPEG and PNG.
+- Desktop wallpaper - A screenshot of the desktop is taken for every screen. Icons and widgets will be included. The cached texture is invalidated when the entire desktop is repainted,
+which can happen when the wallpaper changes, icons are interacted with or when widgets update.
+- Custom - The specified image is scaled for every screen without respecting the aspect ratio. Supported formats are JPEG and PNG.
 
 ### Blur image
 Whether to blur the image used for fake blur. This is only done once.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ https://github.com/taj-ny/kwin-effects-forceblur/assets/79316397/7bae6a16-6c78-4
 ### Image source
 The image to use for fake blur.
 
-- Desktop wallpaper - A screenshot of the desktop is taken for every screen. This option is currently experimental. You may run into issues.
+- Desktop wallpaper - A screenshot of the desktop is taken for every screen.
 - Custom - The image is read from a file and scaled for every screen without respecting the aspect ratio. Supported formats are JPEG and PNG.
 
 ### Blur image

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,9 +18,6 @@ This option will override the blur region specified by the decorations.
 Fixes transparency for some applications by marking their windows as transparent. This will only be done for force-blurred windows.
 
 # Fake blur
-> [!NOTE]  
-> Fake blur doesn't support multiple screens on X11.
-
 Fake blur is mainly intended for laptop users who want longer battery life.
 
 If a window is entirely in front of the wallpaper, why keep blurring the same image over and over? That's a massive waste of resources.

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -371,7 +371,7 @@ void BlurEffect::slotScreenAdded(KWin::Output *screen)
             return;
         }
 
-        m_fakeBlurTextures.remove(screen);
+        m_fakeBlurTextures.erase(screen);
         effects->addRepaintFull();
     });
 }

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -937,9 +937,14 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         projectionMatrix = viewport.projectionMatrix();
         projectionMatrix.translate(deviceBackgroundRect.x(), deviceBackgroundRect.y());
 
+        QRectF screenGeometry;
+        if (m_currentScreen) {
+            screenGeometry = m_currentScreen->geometryF();
+        }
+
         m_texture.shader->setUniform(m_texture.mvpMatrixLocation, projectionMatrix);
         m_texture.shader->setUniform(m_texture.textureSizeLocation, QVector2D(fakeBlurTexture->size().width(), fakeBlurTexture->size().height()));
-        m_texture.shader->setUniform(m_texture.texStartPosLocation, QVector2D(backgroundRect.x(), backgroundRect.y()));
+        m_texture.shader->setUniform(m_texture.texStartPosLocation, QVector2D(backgroundRect.x() - screenGeometry.x(), backgroundRect.y() - screenGeometry.y()));
         m_texture.shader->setUniform(m_texture.blurSizeLocation, QVector2D(backgroundRect.width(), backgroundRect.height()));
         m_texture.shader->setUniform(m_texture.scaleLocation, (float)viewport.scale());
         m_texture.shader->setUniform(m_texture.topCornerRadiusLocation, topCornerRadius);

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -324,7 +324,11 @@ void BlurEffect::slotWindowAdded(EffectWindow *w)
     }
 
     windowExpandedGeometryChangedConnections[w] = connect(w, &EffectWindow::windowExpandedGeometryChanged, this, [this,w]() {
-        if (w) {
+        if (!w) {
+            return;
+        } else if (w->isDesktop() && !effects->waylandDisplay()) {
+            m_fakeBlurTextures.erase(nullptr);
+        } else {
             updateBlurRegion(w, true);
         }
     });
@@ -547,7 +551,7 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
             }
         }
 
-        if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper && w->isDesktop() && w->rect() == data.paint.boundingRect()) {
+        if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper && w->isDesktop() && w->frameGeometry() == data.paint.boundingRect()) {
             m_fakeBlurTextures.erase(m_currentScreen);
         }
     }
@@ -657,92 +661,22 @@ GLTexture *BlurEffect::ensureFakeBlurTexture(const Output *output, const RenderT
         return m_fakeBlurTextures[output].get();
     }
 
+    if (effects->waylandDisplay() && !output) {
+        return nullptr;
+    }
+
     GLenum textureFormat = GL_RGBA8;
     if (renderTarget.texture()) {
         textureFormat = renderTarget.texture()->internalFormat();
     }
-
-    std::unique_ptr<GLTexture> imageTexture;
-    if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper) {
-        EffectWindow *desktop = nullptr;
-        for (EffectWindow *w : effects->stackingOrder()) {
-            if (w && w->isDesktop() && (!output || w->window()->output() == output)) {
-                desktop = w;
-                break;
-            }
-        }
-        if (!desktop) {
-            return nullptr;
-        }
-
-        const auto scale = output ? output->scale() : 1;
-        const auto geometry = snapToPixelGrid(scaledRect(desktop->rect(), scale));
-
-        imageTexture = GLTexture::allocate(textureFormat, geometry.size());
-        imageTexture->setFilter(GL_LINEAR);
-        imageTexture->setWrapMode(GL_CLAMP_TO_EDGE);
-        if (!imageTexture) {
-            return nullptr;
-        }
-        std::unique_ptr<GLFramebuffer> desktopFramebuffer = std::make_unique<GLFramebuffer>(imageTexture.get());
-        if (!desktopFramebuffer->valid()) {
-            return nullptr;
-        }
-
-        const RenderTarget renderTarget(desktopFramebuffer.get());
-        const RenderViewport renderViewport(desktop->rect(), scale, renderTarget);
-        WindowPaintData data;
-
-#ifdef KWIN_6_0
-        QMatrix4x4 projectionMatrix;
-        projectionMatrix.ortho(geometry);
-        data.setProjectionMatrix(projectionMatrix);
-#endif
-
-        GLFramebuffer::pushFramebuffer(desktopFramebuffer.get());
-
-        effects->drawWindow(renderTarget, renderViewport, desktop, PAINT_WINDOW_TRANSFORMED | PAINT_WINDOW_TRANSLUCENT, infiniteRegion(), data);
-        GLFramebuffer::popFramebuffer();
-    } else if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::Custom) {
-        if (m_settings.fakeBlur.customImage.isNull()) {
-            return nullptr;
-        }
-
-        const QSize screenResolution = output ? output->pixelSize() : QGuiApplication::primaryScreen()->size();
-        imageTexture = GLTexture::upload(m_settings.fakeBlur.customImage.scaled(screenResolution, Qt::AspectRatioMode::IgnoreAspectRatio, Qt::TransformationMode::SmoothTransformation));
-    }
-
-    if (!imageTexture)
+    GLTexture *texture = effects->waylandDisplay()
+        ? createFakeBlurTextureWayland(output, renderTarget, textureFormat)
+        : createFakeBlurTextureX11(textureFormat);
+    if (!texture) {
         return nullptr;
-
-    // Transform image colorspace
-    std::unique_ptr<GLTexture> imageTransformedColorspaceTexture = GLTexture::allocate(textureFormat, imageTexture->size());
-    std::unique_ptr<GLFramebuffer> imageTransformedColorspaceFramebuffer = std::make_unique<GLFramebuffer>(imageTransformedColorspaceTexture.get());
-
-    GLShader *shader = ShaderManager::instance()->pushShader(ShaderTrait::MapTexture | ShaderTrait::TransformColorspace);
-    shader->setColorspaceUniforms(
-        ColorDescription::sRGB, renderTarget.colorDescription()
-#if !(defined(KWIN_6_1) || defined(KWIN_6_0))
-        , RenderingIntent::RelativeColorimetricWithBPC
-#endif
-    );
-    QMatrix4x4 projectionMatrix;
-    projectionMatrix.scale(1, -1);
-    projectionMatrix.ortho(QRect(0, 0, imageTexture->width(), imageTexture->height()));
-    shader->setUniform(GLShader::Mat4Uniform::ModelViewProjectionMatrix, projectionMatrix);
-    GLFramebuffer::pushFramebuffer(imageTransformedColorspaceFramebuffer.get());
-
-    imageTexture->render(imageTexture->size());
-    imageTexture = std::move(imageTransformedColorspaceTexture);
-
-    GLFramebuffer::popFramebuffer();
-    ShaderManager::instance()->popShader();
-
-    if (m_settings.fakeBlur.blurCustomImage) {
-        blur(imageTexture.get());
     }
 
-    return (m_fakeBlurTextures[output] = std::move(imageTexture)).get();
+    return (m_fakeBlurTextures[output] = std::unique_ptr<GLTexture>(texture)).get();
 }
 
 GLTexture *BlurEffect::ensureNoiseTexture()
@@ -1054,7 +988,7 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         ShaderManager::instance()->pushShader(m_upsamplePass.shader.get());
 
         QMatrix4x4 projectionMatrix;
-        projectionMatrix.ortho(QRectF(0.0, 0.0, backgroundRect.width(), backgroundRect.height()));
+        projectionMatrix.ortho(QRectF(0.0, 0, backgroundRect.width(), backgroundRect.height()));
 
         m_upsamplePass.shader->setUniform(m_upsamplePass.topCornerRadiusLocation, static_cast<float>(0));
         m_upsamplePass.shader->setUniform(m_upsamplePass.bottomCornerRadiusLocation, static_cast<float>(0));
@@ -1132,6 +1066,150 @@ void BlurEffect::blur(GLTexture *texture)
     GLFramebuffer::pushFramebuffer(blurredFramebuffer.get());
     blur(renderData, renderTarget, renderViewport, nullptr, 0, textureRect, data);
     GLFramebuffer::popFramebuffer();
+}
+
+GLTexture *BlurEffect::wallpaper(EffectWindow *desktop, const qreal &scale, const GLenum &textureFormat)
+{
+    const auto geometry = snapToPixelGrid(scaledRect(desktop->rect(), scale));
+
+    auto texture = GLTexture::allocate(textureFormat, geometry.size());
+    texture->setFilter(GL_LINEAR);
+    texture->setWrapMode(GL_CLAMP_TO_EDGE);
+    if (!texture) {
+        return nullptr;
+    }
+    std::unique_ptr<GLFramebuffer> desktopFramebuffer = std::make_unique<GLFramebuffer>(texture.get());
+    if (!desktopFramebuffer->valid()) {
+        return nullptr;
+    }
+
+    const RenderTarget renderTarget(desktopFramebuffer.get());
+    const RenderViewport renderViewport(desktop->frameGeometry(), scale, renderTarget);
+    WindowPaintData data;
+
+#ifdef KWIN_6_0
+    QMatrix4x4 projectionMatrix;
+        projectionMatrix.ortho(geometry);
+        data.setProjectionMatrix(projectionMatrix);
+#endif
+
+    GLFramebuffer::pushFramebuffer(desktopFramebuffer.get());
+
+    effects->drawWindow(renderTarget, renderViewport, desktop, PAINT_WINDOW_TRANSFORMED | PAINT_WINDOW_TRANSLUCENT, infiniteRegion(), data);
+    GLFramebuffer::popFramebuffer();
+    return texture.release();
+}
+
+GLTexture *BlurEffect::createFakeBlurTextureWayland(const Output *output, const RenderTarget &renderTarget, const GLenum &textureFormat)
+{
+    EffectWindow *desktop = nullptr;
+    for (EffectWindow *w : effects->stackingOrder()) {
+        if (w && w->isDesktop() && (w->window()->output() == output)) {
+            desktop = w;
+            break;
+        }
+    }
+    if (!desktop) {
+        return nullptr;
+    }
+
+    std::unique_ptr<GLTexture> texture;
+    if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper) {
+        texture.reset(wallpaper(desktop, output->scale(), textureFormat));
+    } else if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::Custom) {
+        texture = GLTexture::upload(m_settings.fakeBlur.customImage.scaled(output->pixelSize(), Qt::AspectRatioMode::IgnoreAspectRatio, Qt::TransformationMode::SmoothTransformation));
+    }
+    if (!texture) {
+        return nullptr;
+    }
+
+    // Transform image colorspace
+    auto imageTransformedColorspaceTexture = GLTexture::allocate(textureFormat, texture->size());
+    if (!imageTransformedColorspaceTexture) {
+        return nullptr;
+    }
+    auto imageTransformedColorspaceFramebuffer = std::make_unique<GLFramebuffer>(imageTransformedColorspaceTexture.get());
+    if (!imageTransformedColorspaceFramebuffer->valid()) {
+        return nullptr;
+    }
+
+    auto *shader = ShaderManager::instance()->pushShader(ShaderTrait::MapTexture | ShaderTrait::TransformColorspace);
+    shader->setColorspaceUniforms(
+        ColorDescription::sRGB, renderTarget.colorDescription()
+#if !(defined(KWIN_6_1) || defined(KWIN_6_0))
+        , RenderingIntent::RelativeColorimetricWithBPC
+#endif
+    );
+    QMatrix4x4 projectionMatrix;
+    projectionMatrix.scale(1, -1);
+    projectionMatrix.ortho(QRect(0, 0, texture->width(), texture->height()));
+    shader->setUniform(GLShader::Mat4Uniform::ModelViewProjectionMatrix, projectionMatrix);
+    GLFramebuffer::pushFramebuffer(imageTransformedColorspaceFramebuffer.get());
+
+    texture->render(texture->size());
+    texture = std::move(imageTransformedColorspaceTexture);
+
+    GLFramebuffer::popFramebuffer();
+    ShaderManager::instance()->popShader();
+
+    if (m_settings.fakeBlur.blurCustomImage) {
+        blur(texture.get());
+    }
+
+    return texture.release();
+}
+
+GLTexture *BlurEffect::createFakeBlurTextureX11(const GLenum &textureFormat)
+{
+    std::vector<EffectWindow *> desktops;
+    QRegion desktopGeometries;
+    for (auto *w : effects->stackingOrder()) {
+        if (!w || !w->isDesktop())
+            continue;
+
+        desktops.push_back(w);
+        desktopGeometries += w->frameGeometry().toRect();
+    }
+
+    auto compositeTexture = GLTexture::allocate(textureFormat, desktopGeometries.boundingRect().size());
+    if (!compositeTexture) {
+        return nullptr;
+    }
+    auto compositeTextureFramebuffer = std::make_unique<GLFramebuffer>(compositeTexture.get());
+    if (!compositeTextureFramebuffer->valid()) {
+        return nullptr;
+    }
+
+    GLFramebuffer::pushFramebuffer(compositeTextureFramebuffer.get());
+    ShaderBinder binder(ShaderTrait::MapTexture);
+    for (auto *desktop : desktops) {
+        const auto geometry = desktop->frameGeometry();
+
+        std::unique_ptr<GLTexture> texture;
+        if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper) {
+            texture.reset(wallpaper(desktop, 1, textureFormat));
+        } else if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::Custom) {
+            texture = GLTexture::upload(m_settings.fakeBlur.customImage.scaled(geometry.width(), geometry.height(), Qt::AspectRatioMode::IgnoreAspectRatio, Qt::TransformationMode::SmoothTransformation));
+        }
+        if (!texture) {
+            return nullptr;
+        }
+
+        if (m_settings.fakeBlur.blurCustomImage) {
+            blur(texture.get());
+        }
+
+        QMatrix4x4 projectionMatrix;
+        projectionMatrix.scale(1, -1);
+        projectionMatrix.ortho(QRectF(QPointF(), compositeTexture->size()));
+        projectionMatrix.translate(geometry.x(), geometry.y());
+        binder.shader()->setUniform(GLShader::Mat4Uniform::ModelViewProjectionMatrix, projectionMatrix);
+
+        texture->render(geometry.toRect(), desktop->size());
+    }
+    GLFramebuffer::popFramebuffer();
+
+    return compositeTexture.release();
 }
 
 bool BlurEffect::isActive() const

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -643,7 +643,7 @@ GLTexture *BlurEffect::ensureFakeBlurTexture(const Output *output, const RenderT
 
     std::unique_ptr<GLTexture> imageTexture;
     if (m_settings.fakeBlur.imageSource == FakeBlurImageSource::DesktopWallpaper) {
-        EffectWindow *desktop;
+        EffectWindow *desktop = nullptr;
         for (EffectWindow *w : effects->stackingOrder()) {
             if (w && w->isDesktop() && (!output || w->window()->output() == output)) {
                 desktop = w;

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -653,7 +653,7 @@ GLTexture *BlurEffect::ensureFakeBlurTexture(const Output *output, const RenderT
             return nullptr;
         }
 
-        const QRect geometry = QRect(0, 0, desktop->width(), desktop->height());
+        const QRect geometry = QRect(desktop->x(), desktop->y(), desktop->width(), desktop->height());
         const RenderTarget renderTarget(desktopFramebuffer.get());
         const RenderViewport renderViewport(geometry, output ? output->scale() : 1, renderTarget);
         WindowPaintData data;

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -642,7 +642,9 @@ GLTexture *BlurEffect::ensureFakeBlurTexture(const Output *output, const RenderT
             return nullptr;
         }
 
-        std::unique_ptr<GLTexture> desktopTexture = GLTexture::allocate(textureFormat, desktop->size().toSize());
+        const auto scale = output ? output->scale() : 1;
+        const auto geometry = snapToPixelGrid(scaledRect(desktop->rect(), scale));
+        std::unique_ptr<GLTexture> desktopTexture = GLTexture::allocate(textureFormat, geometry.size());
         desktopTexture->setFilter(GL_LINEAR);
         desktopTexture->setWrapMode(GL_CLAMP_TO_EDGE);
         if (!desktopTexture) {
@@ -653,12 +655,10 @@ GLTexture *BlurEffect::ensureFakeBlurTexture(const Output *output, const RenderT
             return nullptr;
         }
 
-        const QRect geometry = QRect(desktop->x(), desktop->y(), desktop->width(), desktop->height());
         const RenderTarget renderTarget(desktopFramebuffer.get());
-        const RenderViewport renderViewport(geometry, output ? output->scale() : 1, renderTarget);
+        const RenderViewport renderViewport(desktop->rect(), scale, renderTarget);
         WindowPaintData data;
 
-        // TODO Test on 6.1
 #ifdef KWIN_6_0
         QMatrix4x4 projectionMatrix;
         projectionMatrix.ortho(geometry);

--- a/src/blur.h
+++ b/src/blur.h
@@ -95,8 +95,34 @@ private:
     void blur(BlurRenderData &renderInfo, const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data);
     void blur(GLTexture *texture);
 
+    /**
+     * @param output Can be nullptr.
+     * @remark This method shall not be called outside of BlurEffect::blur.
+     * @return The cached fake blur texture. The texture will be created if it doesn't exist.
+     */
     GLTexture *ensureFakeBlurTexture(const Output *output, const RenderTarget &renderTarget);
     GLTexture *ensureNoiseTexture();
+
+    /**
+     * @remark This method shall not be called outside of BlurEffect::blur.
+     * @return A pointer to a texture containing the wallpaper of the specified desktop, or nullptr if an error
+     * occurred. The texture will contain icons and widgets, if there are any.
+     */
+    GLTexture *wallpaper(EffectWindow *desktop, const qreal &scale, const GLenum &textureFormat);
+
+    /**
+     * Creates a fake blur texture for the specified screen.
+     * @remark This method shall not be called outside of BlurEffect::blur.
+     * @return A pointer to the texture, or nullptr if an error occurred.
+     */
+    GLTexture *createFakeBlurTextureWayland(const Output *output, const RenderTarget &renderTarget, const GLenum &textureFormat);
+
+    /**
+     * Creates a composite fake blur texture containing images for all screens.
+     * @return A pointer to the texture, or nullptr if an error occurred.
+     */
+    GLTexture *createFakeBlurTextureX11(const GLenum &textureFormat);
+
 private:
     struct
     {

--- a/src/blur.h
+++ b/src/blur.h
@@ -92,7 +92,7 @@ private:
      * @param w The pointer to the window being blurred, nullptr if an image is being blurred.
      */
     void blur(BlurRenderData &renderInfo, const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data);
-    GLTexture *blur(std::unique_ptr<GLTexture> texture);
+    void blur(GLTexture *texture);
 
     GLTexture *ensureFakeBlurTexture(const Output *output, const RenderTarget &renderTarget);
     GLTexture *ensureNoiseTexture();
@@ -174,7 +174,7 @@ private:
 
     QList<BlurValuesStruct> blurStrengthValues;
 
-    QHash<const Output*, GLTexture*> m_fakeBlurTextures;
+    std::unordered_map<const Output*, std::unique_ptr<GLTexture>> m_fakeBlurTextures;
 
     // Windows to blur even when transformed.
     QList<const EffectWindow*> m_blurWhenTransformed;

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -397,8 +397,8 @@
        <item>
         <widget class="QLabel">
          <property name="text">
-          <string>When fake blur is enabled, an image will be painted behind windows instead of blurring the background,
-resulting in much lower resource and power usage.</string>
+          <string>When enabled, the blur texture will be cached and reused, resulting in much lower GPU usage.
+Works best with tiling.</string>
          </property>
         </widget>
        </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -467,7 +467,7 @@ resulting in much lower resource and power usage. X11 with multiple screens is n
          <item>
           <widget class="QRadioButton" name="kcfg_FakeBlurImageSourceDesktopWallpaper">
            <property name="text">
-            <string>Desktop wallpaper (experimental)</string>
+            <string>Desktop wallpaper</string>
            </property>
           </widget>
          </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -398,7 +398,7 @@
         <widget class="QLabel">
          <property name="text">
           <string>When fake blur is enabled, an image will be painted behind windows instead of blurring the background,
-resulting in much lower resource and power usage. X11 with multiple screens is not supported.</string>
+resulting in much lower resource and power usage.</string>
          </property>
         </widget>
        </item>

--- a/tools/plasma-nested.sh
+++ b/tools/plasma-nested.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Launches a nested Plasma X11 or Wayland session with virtual screens.
+# Usage: ./plasma-nested.sh [x11/wayland]
+
+width=1920
+height=1080
+
+dir=/tmp/kwin-better-blur
+if [ ! -d $dir ]; then
+    mkdir -p $dir/.local/share
+    cp -r ~/.config $dir
+    cp -r ~/.local/share/konsole/ $dir/.local/share
+
+    # Tiling, no window decorations and custom shortcuts make it much harder to test
+    rm -f $dir/.config/kwinrc $dir/.config/breezerc
+fi
+
+if [ "$1" = "x11" ]; then
+    screen1="960/0x540/0+0+0 default"
+    screen2="960/0x500/0+960+40 none"
+    screen3="1500/0x540/0+210+540 none"
+
+    unset XDG_SESSION_TYPE
+    unset WAYLAND_DISPLAY
+
+    Xephyr -screen ${width}x${height} +extension randr +extension glx +xinerama +extension render +extension damage +extension xvideo +extension composite -ac :9 &
+
+    launch_plasma_command="dbus-run-session /bin/sh -c \"
+    DISPLAY=:9
+    HOME=$dir
+    kwin_x11 &
+    sleep 1
+    xrandr --setmonitor A $screen1
+    xrandr --setmonitor B $screen2
+    xrandr --setmonitor C $screen3
+    plasmashell > /dev/null 2>&1
+    \""
+elif [ "$1" == "wayland" ]; then
+    # TODO Use $width and $height
+    launch_plasma_command="
+        HOME=$dir
+        dbus-run-session kwin_wayland --output-count 2 --width 960 --height 960 -- /bin/sh -c \"plasmashell\" > /dev/null 2>&1"
+fi
+
+if [ -f /etc/machine-id ]; then
+    # NixOS
+    nix shell . --command /bin/sh -c "$launch_plasma_command"
+else
+    eval "$launch_plasma_command"
+fi


### PR DESCRIPTION
This fixes the following issues: 
- Fake blur doesn't work on screens other than the primary one
- The image isn't scaled properly
- The image doesn't change when the wallpaper does
- The image may be black if a window had requested blur before the wallpaper appeared
- Fake blur doesn't work properly on X11 with multiple 