### PR TITLE
blur/fake-blur: improve window overlap detection

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -337,6 +337,8 @@ void BlurEffect::slotWindowAdded(EffectWindow *w)
     setupDecorationConnections(w);
 
     updateBlurRegion(w);
+
+    m_allWindows.push_back(w);
 }
 
 void BlurEffect::slotWindowDeleted(EffectWindow *w)
@@ -352,6 +354,9 @@ void BlurEffect::slotWindowDeleted(EffectWindow *w)
     if (auto it = windowExpandedGeometryChangedConnections.find(w); it != windowExpandedGeometryChangedConnections.end()) {
         disconnect(*it);
         windowExpandedGeometryChangedConnections.erase(it);
+    }
+    if (auto it = std::find(m_allWindows.begin(), m_allWindows.end(), w); it != m_allWindows.end()) {
+        m_allWindows.erase(it);
     }
 
     if (m_blurWhenTransformed.contains(w)) {
@@ -501,8 +506,8 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
         if (auto it = m_windows.find(w); it != m_windows.end()) {
             const bool hadWindowBehind = it->second.hasWindowBehind;
             it->second.hasWindowBehind = false;
-            for (const EffectWindow *other: effects->stackingOrder().first(w->window()->stackingOrder())) {
-                if (!other
+            for (EffectWindow *other : m_allWindows) {
+                if (w->window()->stackingOrder() <= other->window()->stackingOrder()
                     || !other->isOnCurrentDesktop()
                     || other->isDesktop()
                     || other->window()->resourceClass() == "xwaylandvideobridge"

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -505,7 +505,8 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
                 if (!other
                     || !other->isOnCurrentDesktop()
                     || other->isDesktop()
-                    || other->window()->resourceClass() == "xwaylandvideobridge") {
+                    || other->window()->resourceClass() == "xwaylandvideobridge"
+                    || other->isMinimized()) {
                     continue;
                 }
 

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -508,8 +508,9 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
             it->second.hasWindowBehind = false;
             for (EffectWindow *other : m_allWindows) {
                 if (w->window()->stackingOrder() <= other->window()->stackingOrder()
-                    || !other->isOnCurrentDesktop()
                     || other->isDesktop()
+                    || !other->isOnCurrentDesktop()
+                    || !other->isOnCurrentActivity()
                     || other->window()->resourceClass() == "xwaylandvideobridge"
                     || other->isMinimized()) {
                     continue;

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -502,7 +502,10 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
             const bool hadWindowBehind = it->second.hasWindowBehind;
             it->second.hasWindowBehind = false;
             for (const EffectWindow *other: effects->stackingOrder().first(w->window()->stackingOrder())) {
-                if (!other || !other->isOnCurrentDesktop() || other->isDesktop()) {
+                if (!other
+                    || !other->isOnCurrentDesktop()
+                    || other->isDesktop()
+                    || other->window()->resourceClass() == "xwaylandvideobridge") {
                     continue;
                 }
 

--- a/src/blur.h
+++ b/src/blur.h
@@ -183,6 +183,15 @@ private:
     QMap<EffectWindow *, QMetaObject::Connection> windowExpandedGeometryChangedConnections;
     std::unordered_map<EffectWindow *, BlurEffectData> m_windows;
 
+    /**
+     * Stores all currently open windows, even those that aren't blurred. Used for determining whether windows are
+     * overlapping.
+     *
+     * Objects retrieved from effects->stackingOrder() and workspace()->stackingOrder() appear to be deleted when
+     * BlurEffect::prePaintWindow is running, so that can't be used.
+     */
+    std::vector<EffectWindow *> m_allWindows;
+
     static BlurManagerInterface *s_blurManager;
     static QTimer *s_blurManagerRemoveTimer;
 };


### PR DESCRIPTION
This PR fixes the following issues related to window overlap detection when **Use real blur for windows that are in front of other windows** is enabled:
- The invisible xwaylandvideobridge window located in the top-left corner was not ignored
- Minimized windows were not ignored
- KWin would sometimes crash when closing a window, possibly caused by the EffectWindow being deleted
- Windows on other activities were not ignored