### PR TITLE
correct support check

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -440,7 +440,7 @@ bool BlurEffect::supported()
 #ifdef KWIN_6_0
     return effects->isOpenGLCompositing() && GLFramebuffer::supported() && GLFramebuffer::blitSupported();
 #else
-    return effects->openglContext() && effects->openglContext()->supportsBlits();
+    return effects->openglContext() && (effects->openglContext()->supportsBlits() || effects->waylandDisplay());
 #endif
 }
 


### PR DESCRIPTION
On Xorg, the effects need support for OpenGL blits, but on Wayland, the screen texture can be used instead

https://invent.kde.org/plasma/kwin/-/commit/b35edf8d301e2073f242bc88c121dd4fca1b1beb