### PR TITLE
blur: free the window's blur textures if it has fake blur

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -820,6 +820,10 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
     GLTexture *fakeBlurTexture = nullptr;
     if (w && hasFakeBlur(w)) {
         fakeBlurTexture = ensureFakeBlurTexture(m_currentScreen, renderTarget);
+        if (fakeBlurTexture) {
+            renderInfo.textures.clear();
+            renderInfo.framebuffers.clear();
+        }
     }
 
     if (!fakeBlurTexture


### PR DESCRIPTION
If a window had real blur but then switched to fake blur, the textures used for real blur would still be kept in memory, even though they may never be used again.