### PR TITLE
Replace libkdecorations2-dev with libkdecorations3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Fixes for blur-related Plasma bugs that haven't been patched yet.
   <br>
 
   ```
-  sudo apt install git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations2-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev
+  sudo apt install git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations3-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev
   ```
 </details>
 


### PR DESCRIPTION
On Kubuntu 25.04, the package `libkdecorations2-dev` no longer has an installation candidate. It is replaced by the package `libkdecorations3-dev`. Installing this package satisfies the build requirements and the effect works without any encountered problems so far.

Terminal output after installing build dependencies from the README.md
```
sudo apt install git cmake g++ extra-cmake-modules qt6-tools-dev kwin-dev libkf6configwidgets-dev gettext libkf6crash-dev libkf6globalaccel-dev libkf6kio-dev libkf6service-dev libkf6notifications-dev libkf6kcmutils-dev libkdecorations2-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-shm0-dev
Package libkdecorations2-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libkdecorations3-dev


Error: Package 'libkdecorations2-dev' has no installation candidate
```