### PR TITLE
blur: clear textures after allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,9 @@ find_package(KWin REQUIRED COMPONENTS
 if(${KWin_VERSION} VERSION_LESS 6.3)
     message(FATAL_ERROR "Better Blur does not support your Plasma version (${KWin_VERSION}). See the README for more information.")
 endif()
+if(${KWin_VERSION} VERSION_GREATER_EQUAL 6.4.0)
+    add_compile_definitions(KWIN_6_4)
+endif()
 
 find_package(KDecoration3 REQUIRED)
 

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -820,13 +820,13 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         }
     }
 
-    glClearColor(0, 0, 0, 0);
     if (!staticBlurTexture
         && (renderInfo.framebuffers.size() != (m_iterationCount + 1)
             || renderInfo.textures[0]->size() != deviceBackgroundRect.size()
             || renderInfo.textures[0]->internalFormat() != textureFormat)) {
         renderInfo.framebuffers.clear();
         renderInfo.textures.clear();
+        glClearColor(0, 0, 0, 0);
 
         for (size_t i = 0; i <= m_iterationCount; ++i) {
             // For very small windows, the width and/or height of the last blur texture may be 0. Creation of

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -820,6 +820,7 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         }
     }
 
+    glClearColor(0, 0, 0, 0);
     if (!staticBlurTexture
         && (renderInfo.framebuffers.size() != (m_iterationCount + 1)
             || renderInfo.textures[0]->size() != deviceBackgroundRect.size()
@@ -845,6 +846,9 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
                 qCWarning(KWIN_BLUR) << "Failed to create an offscreen framebuffer";
                 return;
             }
+            OpenGlContext::currentContext()->pushFramebuffer(framebuffer.get());
+            glClear(GL_COLOR_BUFFER_BIT);
+            OpenGlContext::currentContext()->popFramebuffer();
             renderInfo.textures.push_back(std::move(texture));
             renderInfo.framebuffers.push_back(std::move(framebuffer));
         }

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -846,9 +846,17 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
                 qCWarning(KWIN_BLUR) << "Failed to create an offscreen framebuffer";
                 return;
             }
-            OpenGlContext::currentContext()->pushFramebuffer(framebuffer.get());
+            auto *context =
+#ifdef KWIN_6_4
+                EglContext
+#else
+                OpenGlContext
+#endif
+                ::currentContext();
+            context->pushFramebuffer(framebuffer.get());
             glClear(GL_COLOR_BUFFER_BIT);
-            OpenGlContext::currentContext()->popFramebuffer();
+            context->popFramebuffer();
+
             renderInfo.textures.push_back(std::move(texture));
             renderInfo.framebuffers.push_back(std::move(framebuffer));
         }


### PR DESCRIPTION
> It's not guaranteed that the driver fills them with sane values, if we don't clear them, then areas of the textures that aren't immediately painted to (like when the window starts up partially off-screen) can contain random noise and affect the final result.

https://invent.kde.org/plasma/kwin/-/commit/b81a8635dd40380bbd4e39d4584221caca1abd8f