### PR TITLE
workflows: remove fedora 40, add 42

### DIFF
--- a/.github/workflows/fedora-42.yml
+++ b/.github/workflows/fedora-42.yml
@@ -1,4 +1,4 @@
-name: Fedora 40
+name: Fedora 42
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: fedora:40
+      image: fedora:42
       options: --user root
 
     steps:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Latest Better Blur versions for previous Plasma releases:
 </details>
 
 <details>
-  <summary>Fedora 40, 41</summary>
+  <summary>Fedora 41, 42</summary>
   <br>
 
   ```


### PR DESCRIPTION
40 is EOL since 13.05.2025.