### PR TITLE
fix plugin after kwin split

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
 find_package(ECM REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
 
+option(BETTERBLUR_WAYLAND "Whether to build Better Blur for Wayland if present." ON)
+option(BETTERBLUR_X11 "Whether to build Better Blur for X11 if present." ON)
+
 include(FeatureSummary)
 include(KDEInstallDirs)
 include(KDECMakeSettings)
@@ -69,14 +72,20 @@ find_package(epoxy REQUIRED)
 find_package(X11 REQUIRED)
 find_package(XCB REQUIRED COMPONENTS XCB)
 
-find_package(KWin REQUIRED COMPONENTS
-    kwineffects
-)
-if(${KWin_VERSION} VERSION_LESS 6.3)
-    message(FATAL_ERROR "Better Blur does not support your Plasma version (${KWin_VERSION}). See the README for more information.")
+if(BETTERBLUR_WAYLAND)
+    find_package(KWin COMPONENTS
+	kwineffects
+    )
 endif()
-if(${KWin_VERSION} VERSION_GREATER_EQUAL 6.4.0)
-    add_compile_definitions(KWIN_6_4)
+if(BETTERBLUR_X11)
+    find_package(KWinX11 COMPONENTS
+        kwineffects
+    )
+    set(KWin_VERSION ${KWinX11_VERSION})
+endif()
+
+if(${KWin_VERSION} VERSION_LESS 6.4)
+    message(FATAL_ERROR "Better Blur does not support your Plasma version (${KWin_VERSION}). See the README for more information.")
 endif()
 
 find_package(KDecoration3 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,16 +23,22 @@ kconfig_add_kcfg_files(forceblur_SOURCES
     blurconfig.kcfgc
 )
 
-add_library(forceblur MODULE ${forceblur_SOURCES})
-target_link_libraries(forceblur PRIVATE
-    KWin::kwin
-
-    KF6::ConfigGui
-)
-if (${KDecoration3_FOUND})
-    target_link_libraries(forceblur PRIVATE KDecoration3::KDecoration)
-else()
-    target_link_libraries(forceblur PRIVATE KDecoration2::KDecoration)
+if(BETTERBLUR_WAYLAND)
+    add_library(forceblur MODULE ${forceblur_SOURCES})
+    target_link_libraries(forceblur PRIVATE
+	KDecoration3::KDecoration
+        KF6::ConfigGui
+        KWin::kwin
+    )
+    install(TARGETS forceblur DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/plugins)
 endif()
-
-install(TARGETS forceblur DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/plugins)
+if(BETTERBLUR_X11)
+    add_library(forceblur_x11 MODULE ${forceblur_SOURCES})
+    target_link_libraries(forceblur_x11 PRIVATE
+	KDecoration3::KDecoration
+	KF6::ConfigGui
+	KWinX11::kwin
+    )
+    target_compile_definitions(forceblur_x11 PRIVATE BETTERBLUR_X11)
+    install(TARGETS forceblur_x11 DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin-x11/effects/plugins)
+endif()

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -847,10 +847,10 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
                 return;
             }
             auto *context =
-#ifdef KWIN_6_4
-                EglContext
-#else
+#ifdef BETTERBLUR_X11
                 OpenGlContext
+#else
+                EglContext
 #endif
                 ::currentContext();
             context->pushFramebuffer(framebuffer.get());

--- a/src/kcm/CMakeLists.txt
+++ b/src/kcm/CMakeLists.txt
@@ -17,6 +17,11 @@ target_link_libraries(kwin_better_blur_config
     Qt6::DBus
 )
 
-install(TARGETS kwin_better_blur_config DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/configs)
+if(BETTERBLUR_WAYLAND)
+    install(TARGETS kwin_better_blur_config DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/configs)
+endif()
+if(BETTERBLUR_X11)
+    install(TARGETS kwin_better_blur_config DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin-x11/effects/configs)
+endif()
 
 add_compile_definitions(ABOUT_VERSION_STRING="${PROJECT_VERSION}")


### PR DESCRIPTION
This splits the plugin binary into two, one for X11 and one for Wayland.

Two CMake options are introduced: ``BETTERBLUR_WAYLAND`` and ``BETTERBLUR_X11``, which control whether the Wayland and X11 variants are built. The options are enabled by default but no build will be attempted if the required KWin package is missing. You can set them in the ``cmake`` command:
```
cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DBETTERBLUR_WAYLAND=OFF
```

The minimum Plasma version is now 6.4.

Fixes #206