### PR TITLE
kcm: fix changes not applying under X11

### DIFF
--- a/src/kcm/blur_config.cpp
+++ b/src/kcm/blur_config.cpp
@@ -61,10 +61,11 @@ void BlurEffectConfig::save()
                                          QStringLiteral("/Effects"),
                                          QDBusConnection::sessionBus());
 
-    if(QGuiApplication::platformName() == QStringLiteral("xcb"))
+    if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
         interface.reconfigureEffect(QStringLiteral("forceblur_x11"));
-    else
+    } else {
         interface.reconfigureEffect(QStringLiteral("forceblur"));
+    }
 }
 
 } // namespace KWin


### PR DESCRIPTION
Since the the effect now has two possible IDs (`forceblur` and `forceblur_x11`) because of the KWin 6.4 split, the KCM doesn't account for this and uses the wrong ID when using an X11 session. This MR simply checks the current environment and reconfigures the effect using the appropriate ID. I tried doing this with the CMake build options but for some reason it didn't seem to work, so I just opted for the runtime check instead. 