### PR TITLE
Add COPR Repository for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Latest Better Blur versions for previous Plasma releases:
   ```
 </details>
 <details>
-  <summary>Fedora (COPR)</summary>
+  <summary>Fedora (COPR)*</summary>
   <br>
 
   **This package is usually built against the latest version of KWin available in Fedora's official repositories, with a delay of up to 24 hours due to Fedora's update mechanism using bodhi. If you use a beta/testing/copr/advisory version of KWin, the effect may not work. In that case, you need to either recompile the effect using the instructions below, or rebuild the SRPM using `rpmbuild --rebuild /path/to/srpm.src.rpm`. Uninstall the rpm of the effect before attempting your build.**
@@ -83,6 +83,7 @@ Latest Better Blur versions for previous Plasma releases:
   sudo dnf install --refresh kwin-effects-forceblur
   ```
 </details>
+
 **\* Unofficial package, use at your own risk.**
 
 ## Manual

--- a/README.md
+++ b/README.md
@@ -71,7 +71,18 @@ Latest Better Blur versions for previous Plasma releases:
   }
   ```
 </details>
+<details>
+  <summary>Fedora (COPR)</summary>
+  <br>
 
+  **This package is usually built against the latest version of KWin available in Fedora's official repositories, with a delay of up to 24 hours due to Fedora's update mechanism using bodhi. If you use a beta/testing/copr/advisory version of KWin, the effect may not work. In that case, you need to either recompile the effect using the instructions below, or rebuild the SRPM using `rpmbuild --rebuild /path/to/srpm.src.rpm`. Uninstall the rpm of the effect before attempting your build.**
+
+  [Repository](https://copr.fedorainfracloud.org/coprs/hazel-bunny/ricing/package/kwin-effects-forceblur/)
+  ```
+  sudo dnf copr enable hazel-bunny/ports
+  sudo dnf install --refresh kwin-effects-forceblur
+  ```
+</details>
 **\* Unofficial package, use at your own risk.**
 
 ## Manual


### PR DESCRIPTION
This effect has been built in my copr for about a year, since Fedora 40. Currently the package "just works", with the only limiting factors being:
1. Often needs kwin/plasmashell to be restarted after upgrades
2. Limited free time on my end, often delaying updates

You can check the spec file [here](https://download.copr.fedorainfracloud.org/results/hazel-bunny/ricing/fedora-rawhide-aarch64/09247243-kwin-effects-forceblur/kwin-effects-forceblur.spec) and also try other packages in my copr repository to make sure you and your users could trust my COPR repository.