### PR TITLE
Ignore empty lines in the specified window classes

### DIFF
--- a/src/kcm/blur_config.cpp
+++ b/src/kcm/blur_config.cpp
@@ -59,7 +59,8 @@ void BlurEffectConfig::setContextualHelp(
     KContextualHelpButton *const contextualHelpButton,
     const QString &text,
     QWidget *const heightHintWidget
-) {
+)
+{
     contextualHelpButton->setContextualHelpText(text);
     if (heightHintWidget) {
         const auto ownHeightHint = contextualHelpButton->sizeHint().height();

--- a/src/kcm/blur_config.cpp
+++ b/src/kcm/blur_config.cpp
@@ -37,6 +37,8 @@ BlurEffectConfig::BlurEffectConfig(QObject *parent, const KPluginMetaData &data)
             .replace("${repo}", "https://github.com/taj-ny/kwin-effects-forceblur");
         ui.aboutText->setHtml(html);
     }
+
+    setupContextualHelp();
 }
 
 BlurEffectConfig::~BlurEffectConfig()
@@ -51,6 +53,32 @@ void BlurEffectConfig::slotStaticBlurImagePickerClicked()
     }
 
     ui.kcfg_FakeBlurImage->setText(imagePath);
+}
+
+void BlurEffectConfig::setContextualHelp(
+    KContextualHelpButton *const contextualHelpButton,
+    const QString &text,
+    QWidget *const heightHintWidget
+) {
+    contextualHelpButton->setContextualHelpText(text);
+    if (heightHintWidget) {
+        const auto ownHeightHint = contextualHelpButton->sizeHint().height();
+        const auto otherHeightHint = heightHintWidget->sizeHint().height();
+        if (ownHeightHint >= otherHeightHint) {
+            contextualHelpButton->setHeightHintWidget(heightHintWidget);
+        }
+    }
+}
+
+void BlurEffectConfig::setupContextualHelp()
+{
+    setContextualHelp(
+        ui.windowClassesContextualHelp,
+        QStringLiteral("<p>Specify one window class per line.</p>") +
+        QStringLiteral("<p>Use <code>$blank</code> to match empty window classes.<br/>") +
+        QStringLiteral("Use <code>$$</code> for literal dollar sign.</p>"),
+        ui.windowClassesBriefDescription
+    );
 }
 
 void BlurEffectConfig::save()

--- a/src/kcm/blur_config.h
+++ b/src/kcm/blur_config.h
@@ -8,6 +8,8 @@
 
 #include "ui_blur_config.h"
 #include <KCModule>
+#include <QWidget>
+#include <KContextualHelpButton>
 
 namespace KWin
 {
@@ -27,6 +29,13 @@ private slots:
 
 private:
     ::Ui::BlurEffectConfig ui;
+
+    void setContextualHelp(
+        KContextualHelpButton *const contextualHelpButton,
+        const QString &text,
+        QWidget *const heightHintWidget = nullptr
+    );
+    void setupContextualHelp();
 };
 
 } // namespace KWin

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -577,7 +577,7 @@ the background, resulting in much lower GPU usage.</string>
            <item>
             <layout class="QHBoxLayout">
              <item>
-              <spacer name="horizontalSpacer_2">
+              <spacer name="horizontalSpacer_3">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -273,11 +273,29 @@
       </attribute>
       <layout class="QVBoxLayout">
        <item>
-        <widget class="QLabel">
-         <property name="text">
-          <string>Classes of windows to force blur (one per line, two empty lines to match empty classes):</string>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout">
+         <item>
+          <layout class="QHBoxLayout">
+           <item>
+            <widget class="QLabel" name="windowClassesBriefDescription">
+             <property name="text">
+              <string>Classes of windows to force blur:</string>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="KContextualHelpButton" name="windowClassesContextualHelp">
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QPlainTextEdit" name="kcfg_WindowClasses">
@@ -593,6 +611,15 @@ the background, resulting in much lower GPU usage.</string>
                   <widget class="QPushButton" name="staticBlurImagePicker">
                    <property name="icon">
                     <iconset theme="document-open"/>
+                   </property>
+                   <property name="toolTip">
+                    <string>Choose File...</string>
+                   </property>
+                   <property name="accessibleName">
+                    <string>Choose File...</string>
+                   </property>
+                   <property name="accessibleDescription">
+                    <string>Choose an image file as static blur's source.</string>
                    </property>
                   </widget>
                  </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -275,7 +275,7 @@
        <item>
         <widget class="QLabel">
          <property name="text">
-          <string>Classes of windows to force blur (one per line):</string>
+          <string>Classes of windows to force blur (one per line, two empty lines to match empty classes):</string>
          </property>
         </widget>
        </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -281,6 +281,9 @@
              <property name="text">
               <string>Classes of windows to force blur:</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -358,6 +361,9 @@
         <widget class="QLabel">
          <property name="text">
           <string>The corner radius only applies to the blur region.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -491,8 +497,10 @@
        <item>
         <widget class="QLabel">
          <property name="text">
-          <string>When enabled, a cached texture will be painted behind windows instead of actually blurring
-the background, resulting in much lower GPU usage.</string>
+          <string>When enabled, a cached texture will be painted behind windows instead of actually blurring the background, resulting in much lower GPU usage.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -610,7 +610,7 @@ the background, resulting in much lower GPU usage.</string>
                  <item>
                   <widget class="QPushButton" name="staticBlurImagePicker">
                    <property name="icon">
-                    <iconset theme="document-open"/>
+                    <iconset theme="document-open-symbolic"/>
                    </property>
                    <property name="toolTip">
                     <string>Choose File...</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,7 +15,16 @@ void BlurSettings::read()
     general.saturation = BlurConfig::saturation();
     general.contrast = BlurConfig::contrast();
 
-    forceBlur.windowClasses = BlurConfig::windowClasses().split("\n");
+    forceBlur.windowClasses.clear();
+    bool includeEmpty = false;
+    for (const auto &line : BlurConfig::windowClasses().split("\n")) {
+        if (line.isEmpty() && !includeEmpty) {
+            includeEmpty = true;
+            continue;
+        }
+        includeEmpty = false;
+        forceBlur.windowClasses << line;
+    }
     forceBlur.windowClassMatchingMode = BlurConfig::blurMatching() ? WindowClassMatchingMode::Whitelist : WindowClassMatchingMode::Blacklist;
     forceBlur.blurDecorations = BlurConfig::blurDecorations();
     forceBlur.blurMenus = BlurConfig::blurMenus();


### PR DESCRIPTION
When splitting user specified window classes by line, ignore empty lines. This prevents *unintentionally* matching windows with empty resource class or resource name.  
[To match empty classes and names, use `$blank` as suggested.](https://github.com/taj-ny/kwin-effects-forceblur/pull/226#issuecomment-3077702824)

<details>
<summary>Show resolved</summary>

> When splitting user specified window classes by line, ignore single empty lines. This prevents *unintentionally* matching windows with empty resource class or resource name.
</details>

Fixes #193, fixes #219, fixes #104

A better solution would be to use something like a list with editable items/rows instead of a plain text box, there would be no ambiguities about whether an item should be kept or skipped, but it would greatly increase the implementation complexity.