### PR TITLE
refraction: Add Concave mode, adjust maximums and add corner radius specifically for refraction

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -97,10 +97,12 @@ BlurEffect::BlurEffect()
         m_upsamplePass.blurSizeLocation = m_upsamplePass.shader->uniformLocation("blurSize");
         m_upsamplePass.opacityLocation = m_upsamplePass.shader->uniformLocation("opacity");
         m_upsamplePass.edgeSizePixelsLocation = m_upsamplePass.shader->uniformLocation("edgeSizePixels");
+        m_upsamplePass.refractionCornerRadiusPixelsLocation = m_upsamplePass.shader->uniformLocation("refractionCornerRadiusPixels");
         m_upsamplePass.refractionStrengthLocation = m_upsamplePass.shader->uniformLocation("refractionStrength");
         m_upsamplePass.refractionNormalPowLocation = m_upsamplePass.shader->uniformLocation("refractionNormalPow");
         m_upsamplePass.refractionRGBFringingLocation = m_upsamplePass.shader->uniformLocation("refractionRGBFringing");
         m_upsamplePass.refractionTextureRepeatModeLocation = m_upsamplePass.shader->uniformLocation("refractionTextureRepeatMode");
+        m_upsamplePass.refractionModeLocation = m_upsamplePass.shader->uniformLocation("refractionMode");
     }
 
     m_texture.shader = ShaderManager::instance()->generateShaderFromFile(ShaderTrait::MapTexture,
@@ -1108,10 +1110,12 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         if (w && m_settings.refraction.refractionStrength > 0) {
             m_upsamplePass.shader->setUniform(m_upsamplePass.edgeSizePixelsLocation,
                 std::min(m_settings.refraction.edgeSizePixels, (float)std::min(deviceBackgroundRect.width() / 2, deviceBackgroundRect.height() / 2)));
+            m_upsamplePass.shader->setUniform(m_upsamplePass.refractionCornerRadiusPixelsLocation, m_settings.refraction.refractionCornerRadiusPixels);
             m_upsamplePass.shader->setUniform(m_upsamplePass.refractionStrengthLocation, m_settings.refraction.refractionStrength);
             m_upsamplePass.shader->setUniform(m_upsamplePass.refractionNormalPowLocation, m_settings.refraction.refractionNormalPow);
             m_upsamplePass.shader->setUniform(m_upsamplePass.refractionRGBFringingLocation, m_settings.refraction.refractionRGBFringing);
             m_upsamplePass.shader->setUniform(m_upsamplePass.refractionTextureRepeatModeLocation, m_settings.refraction.refractionTextureRepeatMode);
+            m_upsamplePass.shader->setUniform(m_upsamplePass.refractionModeLocation, m_settings.refraction.refractionMode);
         }
 
         glEnable(GL_BLEND);

--- a/src/blur.h
+++ b/src/blur.h
@@ -159,10 +159,12 @@ private:
         int opacityLocation;
 
         int edgeSizePixelsLocation;
+        int refractionCornerRadiusPixelsLocation;
         int refractionStrengthLocation;
         int refractionNormalPowLocation;
         int refractionRGBFringingLocation;
         int refractionTextureRepeatModeLocation;
+        int refractionModeLocation;
     } m_upsamplePass;
 
     struct

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -91,10 +91,16 @@ class3</default>
         <entry name="RefractionEdgeSize" type="Double">
             <default>20.0</default>
         </entry>
+        <entry name="RefractionCornerRadius" type="Double">
+            <default>8.0</default>
+        </entry>
         <entry name="RefractionRGBFringing" type="Double">
             <default>1.0</default>
         </entry>
         <entry name="RefractionTextureRepeatMode" type="Int">
+            <default>0</default>
+        </entry>
+        <entry name="RefractionMode" type="Int">
             <default>0</default>
         </entry>
     </group>

--- a/src/kcm/blur_config.cpp
+++ b/src/kcm/blur_config.cpp
@@ -15,6 +15,7 @@
 
 #include <QFileDialog>
 #include <QPushButton>
+#include <QComboBox>
 
 namespace KWin
 {
@@ -27,6 +28,28 @@ BlurEffectConfig::BlurEffectConfig(QObject *parent, const KPluginMetaData &data)
     ui.setupUi(widget());
     BlurConfig::instance("kwinrc");
     addConfig(BlurConfig::self(), widget());
+
+    // Disable Edge Behavior when Concave mode is selected - not relevant
+    auto updateEdgeBehaviorEnabled = [this]() {
+        const bool concave = ui.kcfg_RefractionMode && ui.kcfg_RefractionMode->currentIndex() == 1;
+        if (ui.kcfg_RefractionTextureRepeatMode) {
+            ui.kcfg_RefractionTextureRepeatMode->setEnabled(!concave);
+        }
+        if (ui.labelRefractionTextureRepeatMode) {
+            ui.labelRefractionTextureRepeatMode->setEnabled(!concave);
+        }
+        // Corner radius is only relevant for Concave as Basic breaks with low values
+        if (ui.kcfg_RefractionCornerRadius) {
+            ui.kcfg_RefractionCornerRadius->setEnabled(concave);
+        }
+        if (ui.labelRefractionCornerRadius) {
+            ui.labelRefractionCornerRadius->setEnabled(concave);
+        }
+    };
+    if (ui.kcfg_RefractionMode) {
+        connect(ui.kcfg_RefractionMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [updateEdgeBehaviorEnabled](int){ updateEdgeBehaviorEnabled(); });
+        updateEdgeBehaviorEnabled();
+    }
 
     connect(ui.staticBlurImagePicker, &QPushButton::clicked, this, &BlurEffectConfig::slotStaticBlurImagePickerClicked);
 

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -402,7 +402,7 @@
             <number>0</number>
            </property>
            <property name="maximum">
-            <number>20</number>
+             <number>30</number>
            </property>
            <property name="singleStep">
             <number>1</number>
@@ -431,6 +431,47 @@
         </layout>
        </item>
        <item>
+         <widget class="QLabel" name="labelRefractionMode">
+          <property name="text">
+           <string>Refraction Mode:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutRefractionMode">
+          <item>
+           <spacer name="horizontalSpacerRefractionMode">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QComboBox" name="kcfg_RefractionMode">
+            <item>
+             <property name="text">
+              <string>Basic (Bulge)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Concave (Lens)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
         <widget class="QLabel" name="labelRefractionEdgeSize">
          <property name="text">
           <string>Refraction Edge Size:</string>
@@ -468,7 +509,7 @@
             <number>0</number>
            </property>
            <property name="maximum">
-            <number>20</number>
+             <number>30</number>
            </property>
            <property name="singleStep">
             <number>1</number>
@@ -563,6 +604,72 @@
         </layout>
        </item>
        <item>
+        <widget class="QLabel" name="labelRefractionCornerRadius">
+         <property name="text">
+          <string>Refraction Corner Radius:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutCornerRadius">
+         <item>
+          <spacer name="horizontalSpacerCornerRadius">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionNormalPowRound">
+           <property name="text">
+            <string>Square</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="kcfg_RefractionCornerRadius">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>200</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>7</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+           <property name="tickInterval">
+            <number>7</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionNormalPowRound">
+           <property name="text">
+            <string>Round</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QLabel" name="labelRefractionRGBFringing">
          <property name="text">
           <string>RGB Fringing Strength:</string>
@@ -600,7 +707,7 @@
             <number>0</number>
            </property>
            <property name="maximum">
-            <number>20</number>
+             <number>30</number>
            </property>
            <property name="singleStep">
             <number>1</number>
@@ -628,47 +735,50 @@
          </item>
         </layout>
        </item>
-       <item>
-        <widget class="QLabel" name="labelRefractionTextureRepeatMode">
-         <property name="text">
-          <string>Edge Behavior:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayoutTextureRepeatMode">
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="kcfg_RefractionTextureRepeatMode">
-           <item>
-            <property name="text">
-             <string>Clamp (extend edge pixels)</string>
+        <item>
+         <widget class="QLabel" name="labelRefractionTextureRepeatMode">
+          <property name="text">
+           <string>Edge Behavior:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutTextureRepeatMode">
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Flip (mirror texture)</string>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
             </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QComboBox" name="kcfg_RefractionTextureRepeatMode">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <item>
+             <property name="text">
+              <string>Clamp (extend edge pixels)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Flip (mirror texture)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
        <item>
         <spacer name="verticalSpacer">
           <property name="orientation">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -66,10 +66,21 @@ void BlurSettings::read()
     staticBlur.blurCustomImage = BlurConfig::fakeBlurCustomImageBlur();
 
     refraction.edgeSizePixels = BlurConfig::refractionEdgeSize() * 10;
-    refraction.refractionStrength = BlurConfig::refractionStrength() / 20.0;
+
+    {
+        const double maxCorner = 200.0;
+        const double steps = 30.0;
+        const double stepSize = maxCorner / steps; // ≈6.6667
+        const double raw = BlurConfig::refractionCornerRadius();
+        const double snapped = std::round(raw / stepSize) * stepSize;
+        refraction.refractionCornerRadiusPixels = snapped;
+    }
+
+    refraction.refractionStrength = BlurConfig::refractionStrength() / 30.0;
     refraction.refractionNormalPow = BlurConfig::refractionNormalPow() / 2.0;
-    refraction.refractionRGBFringing = BlurConfig::refractionRGBFringing() / 20.0;  // Scale to 0-1 range
+    refraction.refractionRGBFringing = BlurConfig::refractionRGBFringing() / 30.0;
     refraction.refractionTextureRepeatMode = BlurConfig::refractionTextureRepeatMode();
+    refraction.refractionMode = BlurConfig::refractionMode();
 }
 
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -61,10 +61,12 @@ struct StaticBlurSettings
 struct RefractionSettings
 {
     float edgeSizePixels;
+    float refractionCornerRadiusPixels;
     float refractionStrength;
     float refractionNormalPow;
     float refractionRGBFringing;
     int refractionTextureRepeatMode;
+    int refractionMode; // 0: Basic (bulge), 1: Concave (lens)
 };
 
 class BlurSettings

--- a/src/shaders/texture.frag
+++ b/src/shaders/texture.frag
@@ -1,0 +1,43 @@
+uniform float topCornerRadius;
+uniform float bottomCornerRadius;
+uniform float antialiasing;
+
+uniform vec2 blurSize;
+uniform float opacity;
+
+vec4 roundedRectangle(vec2 fragCoord, vec3 texture)
+{
+    if (topCornerRadius == 0 && bottomCornerRadius == 0) {
+        return vec4(texture, opacity);
+    }
+
+    vec2 halfblurSize = blurSize * 0.5;
+    vec2 p = fragCoord - halfblurSize;
+    float radius = 0.0;
+    if ((fragCoord.y <= bottomCornerRadius)
+        && (fragCoord.x <= bottomCornerRadius || fragCoord.x >= blurSize.x - bottomCornerRadius)) {
+        radius = bottomCornerRadius;
+        p.y -= radius;
+    } else if ((fragCoord.y >= blurSize.y - topCornerRadius)
+        && (fragCoord.x <= topCornerRadius || fragCoord.x >= blurSize.x - topCornerRadius)) {
+        radius = topCornerRadius;
+        p.y += radius;
+    }
+    float distance = length(max(abs(p) - (halfblurSize + vec2(0.0, radius)) + radius, 0.0)) - radius;
+
+    float s = smoothstep(0.0, antialiasing, distance);
+    return vec4(texture, mix(1.0, 0.0, s) * opacity);
+}
+
+
+uniform sampler2D texUnit;
+uniform vec2 textureSize;
+uniform vec2 texStartPos;
+
+varying vec2 uv;
+
+void main(void)
+{
+    vec2 tex = (texStartPos.xy + vec2(uv.x, 1.0 - uv.y) * blurSize) / textureSize;
+    gl_FragColor = roundedRectangle(uv * blurSize, texture2D(texUnit, tex).rgb);
+}

--- a/src/shaders/texture_core.frag
+++ b/src/shaders/texture_core.frag
@@ -1,0 +1,47 @@
+#version 140
+
+uniform float topCornerRadius;
+uniform float bottomCornerRadius;
+uniform float antialiasing;
+
+uniform vec2 blurSize;
+uniform float opacity;
+
+vec4 roundedRectangle(vec2 fragCoord, vec3 texture)
+{
+    if (topCornerRadius == 0 && bottomCornerRadius == 0) {
+        return vec4(texture, opacity);
+    }
+
+    vec2 halfblurSize = blurSize * 0.5;
+    vec2 p = fragCoord - halfblurSize;
+    float radius = 0.0;
+    if ((fragCoord.y <= bottomCornerRadius)
+        && (fragCoord.x <= bottomCornerRadius || fragCoord.x >= blurSize.x - bottomCornerRadius)) {
+        radius = bottomCornerRadius;
+        p.y -= radius;
+    } else if ((fragCoord.y >= blurSize.y - topCornerRadius)
+        && (fragCoord.x <= topCornerRadius || fragCoord.x >= blurSize.x - topCornerRadius)) {
+        radius = topCornerRadius;
+        p.y += radius;
+    }
+    float distance = length(max(abs(p) - (halfblurSize + vec2(0.0, radius)) + radius, 0.0)) - radius;
+
+    float s = smoothstep(0.0, antialiasing, distance);
+    return vec4(texture, mix(1.0, 0.0, s) * opacity);
+}
+
+
+uniform sampler2D texUnit;
+uniform vec2 textureSize;
+uniform vec2 texStartPos;
+
+in vec2 uv;
+
+out vec4 fragColor;
+
+void main(void)
+{
+    vec2 tex = (texStartPos.xy + vec2(uv.x, 1.0 - uv.y) * blurSize) / textureSize;
+    fragColor = roundedRectangle(uv * blurSize, texture(texUnit, tex).rgb);
+}

--- a/src/shaders/upsample.frag
+++ b/src/shaders/upsample.frag
@@ -1,4 +1,34 @@
-#include "roundedcorners.glsl"
+uniform float topCornerRadius;
+uniform float bottomCornerRadius;
+uniform float antialiasing;
+
+uniform vec2 blurSize;
+uniform float opacity;
+
+vec4 roundedRectangle(vec2 fragCoord, vec3 texture)
+{
+    if (topCornerRadius == 0 && bottomCornerRadius == 0) {
+        return vec4(texture, opacity);
+    }
+
+    vec2 halfblurSize = blurSize * 0.5;
+    vec2 p = fragCoord - halfblurSize;
+    float radius = 0.0;
+    if ((fragCoord.y <= bottomCornerRadius)
+        && (fragCoord.x <= bottomCornerRadius || fragCoord.x >= blurSize.x - bottomCornerRadius)) {
+        radius = bottomCornerRadius;
+        p.y -= radius;
+    } else if ((fragCoord.y >= blurSize.y - topCornerRadius)
+        && (fragCoord.x <= topCornerRadius || fragCoord.x >= blurSize.x - topCornerRadius)) {
+        radius = topCornerRadius;
+        p.y += radius;
+    }
+    float distance = length(max(abs(p) - (halfblurSize + vec2(0.0, radius)) + radius, 0.0)) - radius;
+
+    float s = smoothstep(0.0, antialiasing, distance);
+    return vec4(texture, mix(1.0, 0.0, s) * opacity);
+}
+
 
 uniform sampler2D texUnit;
 uniform float offset;
@@ -167,7 +197,7 @@ void main(void)
     }
 
     if (noise) {
-        sum += vec4(texture2D(noiseTexture, gl_FragCoord.xy / noiseTextureSize).rrr, 0.0);
+        sum += vec4(texture2D(noiseTexture, vec2(uv.x, 1.0 - uv.y) * blurSize / noiseTextureSize).rrr, 0.0);
     }
 
     gl_FragColor = roundedRectangle(uv * blurSize, sum.rgb);


### PR DESCRIPTION
Added a Concave (lens) refraction mode for a more “Liquid Glass” look, it's a lot closer than the current implementation. Also added a Refraction Corner Radius slider (0–200px, 30 steps) to shape the SDF independently of edge size. Because the concave implementation is a bit "weaker", I've raised the maxima to 30 for the relevant sliders. Added some UI logic for irrelevant options between modes.

Backwards compatibility:
- Default remains Basic (Bulge), matching the previous look.
- Existing configs still work. New corner radius affects Concave only; Bulge path is unchanged aside from range slider changes.

Performance:
- Should be the same - same sampling cost on the final upsample pass.

Over-the-top demo:

https://github.com/user-attachments/assets/27853667-ba04-49dc-87e3-474098fce9ed

Please excuse any LLMy or sloppy code - happy to change, I still do not know C++ or the ecosystem around kwin effects; but it compiles, works and doesn't seem to tank my CPU or GPU.


