### PR TITLE
set translucent flag on all windows with blur or rounded corners

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,9 +14,6 @@ Whether to blur window decorations, including borders. Enable this if your windo
 
 This option will override the blur region specified by the decoration.
 
-### Paint windows as non-opaque
-Fixes transparency for some applications by marking their windows as transparent. This will only be done for force-blurred windows.
-
 # Static blur
 When enabled, the blur texture will be cached and reused. The blurred areas of the window will be marked as opaque, resulting in KWin not painting anything behind them.
 Only one image per screen is cached at a time.

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -540,6 +540,7 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
             data.opaque -= QRect(blurRect.x() + blurRect.width() - topCornerRadius, blurRect.y(), topCornerRadius, topCornerRadius);
             data.opaque -= QRect(blurRect.x(), blurRect.y() + blurRect.height() - bottomCornerRadius, bottomCornerRadius, bottomCornerRadius);
             data.opaque -= QRect(blurRect.x() + blurRect.width() - bottomCornerRadius, blurRect.y() + blurRect.height() - bottomCornerRadius, bottomCornerRadius, bottomCornerRadius);
+            data.mask |= Effect::PAINT_WINDOW_TRANSLUCENT;
         }
     }
 
@@ -576,10 +577,6 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
         }
     }
 
-    if (m_settings.forceBlur.markWindowAsTranslucent && !staticBlur && shouldForceBlur(w)) {
-        data.setTranslucent();
-    }
-
     effects->prePaintWindow(w, data, presentTime);
 
     if (!staticBlur) {
@@ -614,6 +611,9 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
         }
 
         m_currentBlur += blurArea;
+        if (!blurArea.isEmpty()) {
+            data.mask |= Effect::PAINT_WINDOW_TRANSLUCENT;
+        }
     }
 
     m_paintedArea -= data.opaque;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -52,9 +52,6 @@ class3</default>
         <entry name="BlurDocks" type="Bool">
             <default>false</default>
         </entry>
-        <entry name="PaintAsTranslucent" type="Bool">
-            <default>false</default>
-        </entry>
         <entry name="FakeBlur" type="Bool">
             <default>false</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -343,13 +343,6 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QCheckBox" name="kcfg_PaintAsTranslucent">
-         <property name="text">
-          <string>Paint windows as non-opaque (fixes artifacts for some transparent windows)</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="widget">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -46,7 +46,6 @@ void BlurSettings::read()
     forceBlur.blurDecorations = BlurConfig::blurDecorations();
     forceBlur.blurMenus = BlurConfig::blurMenus();
     forceBlur.blurDocks = BlurConfig::blurDocks();
-    forceBlur.markWindowAsTranslucent = BlurConfig::paintAsTranslucent();
 
     roundedCorners.windowTopRadius = BlurConfig::topCornerRadius();
     roundedCorners.windowBottomRadius = BlurConfig::bottomCornerRadius();

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,7 +36,6 @@ struct ForceBlurSettings
     bool blurDecorations;
     bool blurMenus;
     bool blurDocks;
-    bool markWindowAsTranslucent;
 };
 
 struct RoundedCornersSettings


### PR DESCRIPTION
this removes the ``Paint windows as non-opaque`` setting, as there's no reason why those windows should not have the flag