### PR TITLE
Add Fedora package for x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Latest Better Blur versions for previous Plasma releases:
   [Repository](https://copr.fedorainfracloud.org/coprs/hazel-bunny/ricing/package/kwin-effects-forceblur/)
   ```
   sudo dnf copr enable hazel-bunny/ricing
-  sudo dnf install --refresh kwin-effects-forceblur
+  sudo dnf install --refresh kwin-effects-forceblur kwin-effects-forceblur-x11 # Install x11 version only if you use kwin-x11
   ```
 </details>
 


### PR DESCRIPTION
The packaging spec has been updated in an attempt to add support for RHEL. The kwin-effects-forceblur package has been split into a main package for wayland and a subpackage for x11. This commit updates the readme to include both packages.