### PR TITLE
chore: mention fedora 43 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Latest Better Blur versions for previous Plasma releases:
 </details>
 
 <details>
-  <summary>Fedora 41, 42</summary>
+  <summary>Fedora 41, 42, 43</summary>
   <br>
 
   Wayland:


### PR DESCRIPTION
The build I made on 42 worked with no problems after upgrading to 43. Furthermore, all the dependencies are present in the 43 repo and it builds successfully.